### PR TITLE
Secret generation using go-password package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ofc-bootstrap
 tmp
 bootstrap
+.idea

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:1af58d182e3b1008d25d7ba65ff7c2631a246023d3b814f9ba8c7919aded59f3"
+  name = "github.com/sethvargo/go-password"
+  packages = ["password"]
+  pruneopts = "UT"
+  revision = "bc15c697eeda69a082991d2f1ed37660658fea32"
+  version = "v0.1.2"
+
+[[projects]]
   digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -12,6 +20,9 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = ["gopkg.in/yaml.v2"]
+  input-imports = [
+    "github.com/sethvargo/go-password/password",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,3 +32,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/sethvargo/go-password"
+  version = "0.1.2"

--- a/pkg/utils/secrets.go
+++ b/pkg/utils/secrets.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alexellis/ofc-bootstrap/pkg/types"
+
+	"github.com/sethvargo/go-password/password"
+)
+
+type secretDesc struct {
+	length      int
+	numDigits   int
+	numSymbols  int
+	noUpper     bool
+	allowRepeat bool
+}
+
+func newDefaultSecretDesc() *secretDesc {
+	return &secretDesc{
+		length:      16,
+		numDigits:   4,
+		numSymbols:  4,
+		allowRepeat: true,
+	}
+}
+
+func defaultSecretGenerator(sd *secretDesc) (string, error) {
+	secretParams := sd
+
+	if secretParams == nil {
+		secretParams = newDefaultSecretDesc()
+	}
+
+	return password.Generate(
+		secretParams.length,
+		secretParams.numDigits,
+		secretParams.numSymbols,
+		secretParams.noUpper,
+		secretParams.allowRepeat,
+	)
+}
+
+func CreateDockerSecret(kvn types.KeyValueNamespaceTuple, secretGenerator func(*secretDesc) (string, error)) string {
+	if secretGenerator == nil {
+		secretGenerator = defaultSecretGenerator
+	}
+
+	val, err := secretGenerator(nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+
+		os.Exit(1)
+	}
+
+	return fmt.Sprintf("echo %s | docker secret create %s", val, kvn.Name)
+}
+
+func CreateK8sSecret(kvn types.KeyValueNamespaceTuple, secretGenerator func(*secretDesc) (string, error)) string {
+	if secretGenerator == nil {
+		secretGenerator = defaultSecretGenerator
+	}
+
+	val, err := secretGenerator(nil)
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	return fmt.Sprintf(
+		"kubectl create secret generic -n %s %s --from-literal s3-access-key=\"%s\"",
+		kvn.Namespace,
+		kvn.Name,
+		val,
+	)
+}

--- a/pkg/utils/secrets_test.go
+++ b/pkg/utils/secrets_test.go
@@ -1,0 +1,155 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/alexellis/ofc-bootstrap/pkg/types"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func Test_defaultSecretGenerator_defaultSecretDesc(t *testing.T) {
+	defaultSecretDesc := newDefaultSecretDesc()
+	pass, err := defaultSecretGenerator(nil)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(pass) != defaultSecretDesc.length {
+		t.Errorf(
+			"Length of password is incorrect. Expected: %d. Received: %d",
+			defaultSecretDesc.length,
+			len(pass),
+		)
+	}
+
+	re := regexp.MustCompile("[0-9]")
+	digitsCount := len(re.FindAllString(pass, -1))
+
+	if digitsCount != defaultSecretDesc.numDigits {
+		t.Errorf(
+			"Amount of digits is incorrent. Expected: %d. Received: %d",
+			defaultSecretDesc.numDigits,
+			digitsCount,
+		)
+	}
+
+	re = regexp.MustCompile("[^a-zA-Z0-9]")
+	symbolsCount := len(re.FindAllString(pass, -1))
+
+	if symbolsCount != defaultSecretDesc.numSymbols {
+		t.Errorf(
+			"Amount of symbols is incorrent. Expected: %d. Received: %d",
+			defaultSecretDesc.numSymbols,
+			symbolsCount,
+		)
+	}
+
+	if !defaultSecretDesc.allowRepeat {
+		uniqCharsLen := len(RemoveDuplicates(strings.Split(pass, "")))
+
+		if uniqCharsLen != defaultSecretDesc.length {
+			t.Errorf(
+				"Expected: %d unique characters. Received: %d",
+				defaultSecretDesc.length,
+				uniqCharsLen,
+			)
+		}
+	}
+
+	if defaultSecretDesc.noUpper {
+		re := regexp.MustCompile("[^A-Z]")
+		notUpperCharsLen := len(re.FindAllString(pass, -1))
+
+		if notUpperCharsLen != defaultSecretDesc.length {
+			t.Errorf(
+				"Expected: %d not upper-case characters. Received: %d",
+				defaultSecretDesc.length,
+				notUpperCharsLen,
+			)
+		}
+	}
+}
+
+func TestCreateDockerSecret_successfulSecretGeneration(t *testing.T) {
+	expectedName := "foo"
+	expectedSecret := "baz_foo_bar"
+	expectedCmd := fmt.Sprintf("echo %s | docker secret create %s", expectedSecret, expectedName)
+	kvn := types.KeyValueNamespaceTuple{ Name: expectedName }
+
+	cmd := CreateDockerSecret(kvn, func(sd *secretDesc) (string, error) {
+		return expectedSecret, nil
+	})
+
+	if cmd != expectedCmd {
+		t.Errorf("Expected to receive command: `%s`. Received: `%s`", expectedCmd, cmd)
+	}
+}
+
+func TestCreateDockerSecret_unsuccessfulSecretGeneration(t *testing.T) {
+	kvn := types.KeyValueNamespaceTuple{ Name: "foo" }
+
+	if os.Getenv("BE_CRASHING_SECRET_GENERATION") == "1" {
+		CreateDockerSecret(kvn, func(sd *secretDesc) (string, error) {
+			return "", fmt.Errorf("some error message")
+		})
+
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestCreateDockerSecret_unsuccessfulSecretGeneration")
+	cmd.Env = append(os.Environ(), "BE_CRASHING_SECRET_GENERATION=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+
+	t.Fatalf("Process ran with err %v, want os.Exit(1)", err)
+}
+
+func TestCreateK8sSecret_successfulSecretGeneration(t *testing.T) {
+	expectedName := "foo"
+	expectedNamespace := "baz_namespace"
+	expectedSecret := "baz_foo_bar"
+	expectedCmd := fmt.Sprintf(
+		"kubectl create secret generic -n %s %s --from-literal s3-access-key=\"%s\"",
+		expectedNamespace,
+		expectedName,
+		expectedSecret,
+	)
+	kvn := types.KeyValueNamespaceTuple{ Name: expectedName, Namespace: expectedNamespace }
+
+	cmd := CreateK8sSecret(kvn, func(sd *secretDesc) (string, error) {
+		return expectedSecret, nil
+	})
+
+	if cmd != expectedCmd {
+		t.Errorf("Expected to receive command: `%s`. Received: `%s`", expectedCmd, cmd)
+	}
+}
+
+func TestCreateK8sSecret_unsuccessfulSecretGeneration(t *testing.T) {
+	kvn := types.KeyValueNamespaceTuple{}
+
+	if os.Getenv("BE_CRASHING_SECRET_GENERATION") == "1" {
+		CreateK8sSecret(kvn, func(sd *secretDesc) (string, error) {
+			return "", fmt.Errorf("some error message")
+		})
+
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestCreateK8sSecret_unsuccessfulSecretGeneration")
+	cmd.Env = append(os.Environ(), "BE_CRASHING_SECRET_GENERATION=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+
+	t.Fatalf("Process ran with err %v, want os.Exit(1)", err)
+}

--- a/pkg/utils/testing.go
+++ b/pkg/utils/testing.go
@@ -1,0 +1,21 @@
+package utils
+
+func RemoveDuplicates(elements []string) []string {
+	var result []string
+
+	for i := 0; i < len(elements); i++ {
+		// Scan slice for a previous element of the same value.
+		exists := false
+		for v := 0; v < i; v++ {
+			if elements[v] == elements[i] {
+				exists = true
+				break
+			}
+		}
+		// If no previous element exists, append this one.
+		if !exists {
+			result = append(result, elements[i])
+		}
+	}
+	return result
+}

--- a/vendor/github.com/sethvargo/go-password/LICENSE
+++ b/vendor/github.com/sethvargo/go-password/LICENSE
@@ -1,0 +1,20 @@
+Copyright 2017 Seth Vargo <seth@sethvargo.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/sethvargo/go-password/password/generate.go
+++ b/vendor/github.com/sethvargo/go-password/password/generate.go
@@ -1,0 +1,242 @@
+// Package password provides a library for generating high-entropy random
+// password strings via the crypto/rand package.
+//
+//    res, err := Generate(64, 10, 10, false, false)
+//    if err != nil  {
+//      log.Fatal(err)
+//    }
+//    log.Printf(res)
+//
+// Most functions are safe for concurrent use.
+package password
+
+import (
+	"crypto/rand"
+	"errors"
+	"math/big"
+	"strings"
+)
+
+const (
+	// LowerLetters is the list of lowercase letters.
+	LowerLetters = "abcdefghijklmnopqrstuvwxyz"
+
+	// UpperLetters is the list of uppercase letters.
+	UpperLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	// Digits is the list of permitted digits.
+	Digits = "0123456789"
+
+	// Symbols is the list of symbols.
+	Symbols = "~!@#$%^&*()_+`-={}|[]\\:\"<>?,./"
+)
+
+var (
+	// ErrExceedsTotalLength is the error returned with the number of digits and
+	// symbols is greater than the total length.
+	ErrExceedsTotalLength = errors.New("number of digits and symbols must be less than total length")
+
+	// ErrLettersExceedsAvailable is the error returned with the number of letters
+	// exceeds the number of available letters and repeats are not allowed.
+	ErrLettersExceedsAvailable = errors.New("number of letters exceeds available letters and repeats are not allowed")
+
+	// ErrDigitsExceedsAvailable is the error returned with the number of digits
+	// exceeds the number of available digits and repeats are not allowed.
+	ErrDigitsExceedsAvailable = errors.New("number of digits exceeds available digits and repeats are not allowed")
+
+	// ErrSymbolsExceedsAvailable is the error returned with the number of symbols
+	// exceeds the number of available symbols and repeats are not allowed.
+	ErrSymbolsExceedsAvailable = errors.New("number of symbols exceeds available symbols and repeats are not allowed")
+)
+
+// Generator is the stateful generator which can be used to customize the list
+// of letters, digits, and/or symbols.
+type Generator struct {
+	lowerLetters string
+	upperLetters string
+	digits       string
+	symbols      string
+}
+
+// GeneratorInput is used as input to the NewGenerator function.
+type GeneratorInput struct {
+	LowerLetters string
+	UpperLetters string
+	Digits       string
+	Symbols      string
+}
+
+// NewGenerator creates a new Generator from the specified configuration. If no
+// input is given, all the default values are used. This function is safe for
+// concurrent use.
+func NewGenerator(i *GeneratorInput) (*Generator, error) {
+	if i == nil {
+		i = new(GeneratorInput)
+	}
+
+	g := &Generator{
+		lowerLetters: i.LowerLetters,
+		upperLetters: i.UpperLetters,
+		digits:       i.Digits,
+		symbols:      i.Symbols,
+	}
+
+	if g.lowerLetters == "" {
+		g.lowerLetters = LowerLetters
+	}
+
+	if g.upperLetters == "" {
+		g.upperLetters = UpperLetters
+	}
+
+	if g.digits == "" {
+		g.digits = Digits
+	}
+
+	if g.symbols == "" {
+		g.symbols = Symbols
+	}
+
+	return g, nil
+}
+
+// Generate generates a password with the given requirements. length is the
+// total number of characters in the password. numDigits is the number of digits
+// to include in the result. numSymbols is the number of symbols to include in
+// the result. noUpper excludes uppercase letters from the results. allowRepeat
+// allows characters to repeat.
+//
+// The algorithm is fast, but it's not designed to be performant; it favors
+// entropy over speed. This function is safe for concurrent use.
+func (g *Generator) Generate(length, numDigits, numSymbols int, noUpper, allowRepeat bool) (string, error) {
+	letters := g.lowerLetters
+	if !noUpper {
+		letters += g.upperLetters
+	}
+
+	chars := length - numDigits - numSymbols
+	if chars < 0 {
+		return "", ErrExceedsTotalLength
+	}
+
+	if !allowRepeat && chars > len(letters) {
+		return "", ErrLettersExceedsAvailable
+	}
+
+	if !allowRepeat && numDigits > len(g.digits) {
+		return "", ErrDigitsExceedsAvailable
+	}
+
+	if !allowRepeat && numSymbols > len(g.symbols) {
+		return "", ErrSymbolsExceedsAvailable
+	}
+
+	var result string
+
+	// Characters
+	for i := 0; i < chars; i++ {
+		ch, err := randomElement(letters)
+		if err != nil {
+			return "", err
+		}
+
+		if !allowRepeat && strings.Contains(result, ch) {
+			i--
+			continue
+		}
+
+		result, err = randomInsert(result, ch)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Digits
+	for i := 0; i < numDigits; i++ {
+		d, err := randomElement(g.digits)
+		if err != nil {
+			return "", err
+		}
+
+		if !allowRepeat && strings.Contains(result, d) {
+			i--
+			continue
+		}
+
+		result, err = randomInsert(result, d)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Symbols
+	for i := 0; i < numSymbols; i++ {
+		sym, err := randomElement(g.symbols)
+		if err != nil {
+			return "", err
+		}
+
+		if !allowRepeat && strings.Contains(result, sym) {
+			i--
+			continue
+		}
+
+		result, err = randomInsert(result, sym)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return result, nil
+}
+
+// MustGenerate is the same as Generate, but panics on error.
+func (g *Generator) MustGenerate(length, numDigits, numSymbols int, noUpper, allowRepeat bool) string {
+	res, err := g.Generate(length, numDigits, numSymbols, noUpper, allowRepeat)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+// See Generator.Generate for usage.
+func Generate(length, numDigits, numSymbols int, noUpper, allowRepeat bool) (string, error) {
+	gen, err := NewGenerator(nil)
+	if err != nil {
+		return "", err
+	}
+
+	return gen.Generate(length, numDigits, numSymbols, noUpper, allowRepeat)
+}
+
+// See Generator.MustGenerate for usage.
+func MustGenerate(length, numDigits, numSymbols int, noUpper, allowRepeat bool) string {
+	res, err := Generate(length, numDigits, numSymbols, noUpper, allowRepeat)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+// randomInsert randomly inserts the given value into the given string.
+func randomInsert(s, val string) (string, error) {
+	if s == "" {
+		return val, nil
+	}
+
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(s)+1)))
+	if err != nil {
+		return "", err
+	}
+	i := n.Int64()
+	return s[0:i] + val + s[i:len(s)], nil
+}
+
+// randomElement extracts a random element from the given string.
+func randomElement(s string) (string, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(s))))
+	if err != nil {
+		return "", err
+	}
+	return string(s[n.Int64()]), nil
+}


### PR DESCRIPTION
Closing: https://github.com/alexellis/ofc-bootstrap/issues/1

Instead of using shell command to generate secrets
they are generated now with go-password package

Unit tests included + moved functions related to secrets
to separate directory pkg/utils

Added .idea directory to .gitignore

Signed-off-by: Bart Smykla <bsmykla@vmware.com>