### PR TITLE
Default init.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Help is wanted - the code is in a private repo for OpenFaaS maintainers to contr
 Status:
 * [ ] Flag: Add dry-run to init.yaml
 * [x] Step: generate `payload_secret` for trust
-* [ ] Refactor: default to init.yaml if present
+* [x] Refactor: default to init.yaml if present
 * [x] Step: Clone OpenFaaS Cloud repo https://github.com/openfaas/openfaas-cloud
 * [ ] Step: deploy container builder (buildkit)
 * [x] Step: Add Ingress controller

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ const (
 func main() {
 
 	vars := Vars{}
-	flag.StringVar(&vars.YamlFile, "yaml", "", "YAML file for bootstrap")
+	flag.StringVar(&vars.YamlFile, "yaml", "init.yaml", "YAML file for bootstrap")
 	flag.BoolVar(&vars.Verbose, "verbose", false, "control verbosity")
 	flag.Parse()
 


### PR DESCRIPTION
With this change one will not need to pass `--yaml` flag when using the default `init.yaml` file

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Closes #6 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`go run main.go` and it uses `init.yaml` without the flag

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests N/A

