### PR TITLE
Add pause to execution for better user experience

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,15 +39,19 @@ func validatePlan(plan types.Plan) error {
 }
 
 func main() {
+	var pauseTime time.Duration = 5
+	defaultYaml := "init.yaml"
 
 	vars := Vars{}
-	flag.StringVar(&vars.YamlFile, "yaml", "init.yaml", "YAML file for bootstrap")
+	flag.StringVar(&vars.YamlFile, "yaml", "", "YAML file for bootstrap")
 	flag.BoolVar(&vars.Verbose, "verbose", false, "control verbosity")
 	flag.Parse()
 
 	if len(vars.YamlFile) == 0 {
-		fmt.Fprintf(os.Stderr, "No -yaml flag given\n")
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "No -yaml flag given. Loading plan from the default yaml file: %s\n", defaultYaml)
+		fmt.Fprintf(os.Stdout, "Continuing in %d seconds.. Press Control+C to cancel\n", pauseTime)
+		vars.YamlFile = defaultYaml
+		time.Sleep(pauseTime * time.Second)
 	}
 
 	yamlBytes, yamlErr := ioutil.ReadFile(vars.YamlFile)


### PR DESCRIPTION
## Description
When running the program it starts running the default execution plan
without warning. This can cause a bad user experience if they are
unsure of what to expect.

Adding a small wait step to ensure there is opportunity to cancel
and review what will be executed before changes are made

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

Additionally, the check for empty `yaml` flag was unnecessary as there was already a default value provided in the flag definition. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the application `go run main.go` 
Wait 5 seconds and watch it continue
Run again and press `ctrl+c` to cancel

## Checklist:

I have:

- [X] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests

