### PR TITLE
Fix failing git clone

### DIFF
--- a/scripts/clone-cloud-components.sh
+++ b/scripts/clone-cloud-components.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+rm -rf ./tmp/openfaas-cloud
+
 git clone https://github.com/openfaas/openfaas-cloud ./tmp/openfaas-cloud

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+rm -rf ./tmp/generated-*
 cp ./tmp/generated-gateway_config.yml ./tmp/openfaas-cloud/gateway_config.yml
 cp ./tmp/generated-github.yml ./tmp/openfaas-cloud/github.yml
 cp ./tmp/generated-dashboard_config.yml ./tmp/openfaas-cloud/dashboard/dashboard_config.yml


### PR DESCRIPTION
Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

## Description

If `/tmp/openfaas-cloud` already exists, run fails on `git clone` and if a re-run is done, it will not use latest `openfaas-cloud `master, but may be stick to some very old version

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
go run main.go

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md N/A
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests N/A

