### PR TITLE
Generate secrets for auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Status:
 * [x] Create basic-auth secrets for the functions in `openfaas-fn`
 * [x] Step: Install Minio and generate keys
 * [ ] init.yml - define and OAuth App and load via struct
-* [ ] Step: generate secrets and keys for the auth service (see auth/README.md)
+* [x] Step: generate secrets and keys for the auth service (see auth/README.md)
 * [ ] Template: auth service deployment YAML file
 * [ ] Refactor: Generate passwords via Golang code or library
 

--- a/init.yaml
+++ b/init.yaml
@@ -21,6 +21,16 @@ secrets:
       - name: payload-secret
         value: ""
     namespace: "openfaas"
+  - name: "jwt-private-key"
+    files:
+      - name: "key"
+        value_from: "./key"
+    namespace: "openfaas"
+  - name: "jwt-public-key"
+    files:
+      - name: "key.pub"
+        value_from: "./key.pub"
+    namespace: "openfaas"
 
   ### User-input
   # Enter into GitHub UI
@@ -35,6 +45,12 @@ secrets:
       - name: "private-key"
         value_from: "~/Downloads/ofc-bootstrap-test.2018-12-20.private-key.pem"
     namespace: "openfaas-fn"
+  # Enter your OAuth client_secret
+  - name: "of-client-secret"
+    literals:
+      - name: of-client-secret
+        value: "fb58e886977efbece9cd77452be27e9"
+    namespace: "openfaas"
 
 ### User input
   - name: "registry-secret"
@@ -54,6 +70,11 @@ tls: false
 ## Populate from GitHub App
 github:
   app_id: "22586"
+
+## Populate from OAuth App
+oauth:
+  client_id: 914f3fb036ce9cd774
+  client_secret: fb58e886977efbece9cd77452be27e9
 
 ### Users allowed to access your OpenFaaS Cloud
 customers_url: "https://raw.githubusercontent.com/openfaas/openfaas-cloud/master/CUSTOMERS"

--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ func process(plan types.Plan) error {
 			log.Println(installIngressErr.Error())
 		}
 
+		generateJwtKeys()
 		createSecrets(plan)
 
 		minioErr := installMinio()
@@ -448,6 +449,22 @@ func cloneCloudComponents() error {
 func deployCloudComponents() error {
 	task := execute.ExecTask{
 		Command: "./scripts/deploy-cloud-components.sh",
+		Shell:   true,
+	}
+
+	res, err := task.Execute()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(res)
+
+	return nil
+}
+
+func generateJwtKeys() error {
+	task := execute.ExecTask{
+		Command: "./scripts/generate-jwt-keys.sh",
 		Shell:   true,
 	}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -13,6 +13,7 @@ type Plan struct {
 	CustomersURL  string                   `yaml:"customers_url"`
 	Github        Github                   `yaml:"github"`
 	TLS           bool                     `yaml:"tls"`
+	OAuth         OAuth                    `yaml:"oauth"`
 }
 
 type KeyValueTuple struct {
@@ -43,4 +44,9 @@ type KeyValueNamespaceTuple struct {
 type Github struct {
 	AppID          string `yaml:"app_id"`
 	PrivateKeyFile string `yaml:"private_key_filename"`
+}
+
+type OAuth struct {
+	ClientId     string `yaml:"client_id`
+	ClientSecret string `yaml:"client_secret`
 }

--- a/scripts/generate-jwt-keys.sh
+++ b/scripts/generate-jwt-keys.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Remove old keys
+rm -rf ./key ./key.pub
+
+# Private key
+openssl ecparam -genkey -name prime256v1 -noout -out key
+
+# Public key
+openssl ec -in key -pubout -out key.pub


### PR DESCRIPTION
This generates secrets for the JWT and of-client-secret 

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`go run main.go`

```
$ kubectl get secrets -n openfaas
NAME                              TYPE                                  DATA   AGE
...
jwt-private-key                   Opaque                                1      1m
jwt-public-key                    Opaque                                1      1m
of-client-secret                  Opaque                                1      1m
...
```

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests N/A

