### PR TITLE
adds templates for s3 properties

### DIFF
--- a/init.yaml
+++ b/init.yaml
@@ -91,6 +91,13 @@ oauth:
 ### Users allowed to access your OpenFaaS Cloud
 customers_url: "https://raw.githubusercontent.com/openfaas/openfaas-cloud/master/CUSTOMERS"
 
+## S3 configuration. These default to minio settings
+s3:
+  s3_url: cloud-minio.openfaas.svc.cluster.local:9000
+  s3_region: us-east-1
+  s3_tls: false
+  s3_bucket: pipeline
+
 ## Enable auth:
 enable_oauth: false
 

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -13,6 +13,7 @@ type gatewayConfig struct {
 	RootDomain   string
 	CustomersURL string
 	Scheme       string
+	S3           types.S3
 }
 
 type authConfig struct {
@@ -34,6 +35,7 @@ func Apply(plan types.Plan) error {
 		RootDomain:   plan.RootDomain,
 		CustomersURL: plan.CustomersURL,
 		Scheme:       scheme,
+		S3:           plan.S3,
 	})
 	if gwConfigErr != nil {
 		return gwConfigErr

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -14,6 +14,7 @@ type Plan struct {
 	Github        Github                   `yaml:"github"`
 	TLS           bool                     `yaml:"tls"`
 	OAuth         OAuth                    `yaml:"oauth"`
+	S3            S3                       `yaml:"s3"`
 	EnableOAuth   bool                     `yaml:"enable_oauth"`
 	TLSConfig     TLSConfig                `yaml:"tls_config"`
 }
@@ -55,6 +56,13 @@ type Github struct {
 type OAuth struct {
 	ClientId     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`
+}
+
+type S3 struct {
+	Url    string `yaml:"s3_url"`
+	Region string `yaml:"s3_region"`
+	TLS    bool   `yaml:"s3_tls"`
+	Bucket string `yaml:"s3_bucket"`
 }
 
 type TLSConfig struct {

--- a/templates/gateway_config.yml
+++ b/templates/gateway_config.yml
@@ -21,10 +21,10 @@ environment:
   builder_url: http://of-builder.openfaas:8080/
 
 # Logging
-  s3_url: cloud-minio.openfaas.svc.cluster.local:9000
-  s3_region: us-east-1
-  s3_tls: false
-  s3_bucket: pipeline
+  s3_url: {{.S3.Url}}
+  s3_region: {{.S3.Region}}
+  s3_tls: {{.S3.TLS}}
+  s3_bucket: {{.S3.Bucket}}
 
 # Function policy
   readonly_root_filesystem: true


### PR DESCRIPTION
## Description

- adds S3 type to types.go
- adds S3 property to gateway_config struct passed into templates
- uses S3 properties in gateway_config.yaml template
- adds s3 properties to init.yaml defaulting to minio defaults
- closes #21

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I only ran the code to read the `init.yaml` file and generate the templates using `stack.Apply(plan)`.

## Checklist:

I have:

- [X] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests

## TODO:

I'll update any parts of the README.md that are necessary for specifying how to configure S3.
Also, if there is a better naming convention to use for the properties, let me know. Right now, in `init.yaml` there's a main block called `s3:` then all of the properties are prefixed with `s3_`, which seems redundant.

Signed-off-by: doowb <brian.woodward@gmail.com>
