### PR TITLE
Template Issuer and certificates for enabled TLS

### DIFF
--- a/init.yaml
+++ b/init.yaml
@@ -53,6 +53,17 @@ secrets:
       - name: of-client-secret
         value: "fb58e886977efbece9cd77452be27e9"
     namespace: "openfaas"
+  # DNS Service Account secret
+  - name: "route53-credentials-secret"
+    files:
+      - name: "secret-access-key"
+        value_from: "/Downloads/secret-access-key"
+    namespace: "kube-system"
+  # - name: "clouddns-service-account"
+  #   files:
+  #     - name: "service-account.json"
+  #       value_from: "/Downloads/service-account.json"
+  #   namespace: "kube-system"
 
 ### User input
   - name: "registry-secret"
@@ -67,7 +78,6 @@ registry: docker.io/ofctest/
 
 ### Domain name registered with A record pointing to *.domain (wild-card)
 root_domain: "stag.o6s.io"
-tls: false
 
 ## Populate from GitHub App
 github:
@@ -84,3 +94,20 @@ customers_url: "https://raw.githubusercontent.com/openfaas/openfaas-cloud/master
 ## Enable auth:
 enable_oauth: false
 
+## TLS
+tls: false
+tls_config:
+  ## Select DNS web service between Amazon Route 53 (route53) and Google Cloud DNS (clouddns)
+  # by uncommenting the required option
+  dns_service: route53
+  region: us-east-1
+  access_key_id: ASYAKIUJE8AYRQQ7DU3M
+
+  # dns_service: clouddns
+  # project_id: "my-openfaas-cloud"
+
+  email: "email@domain"
+  issuer_type: "prod"
+  letsencrypt_server: https://acme-v02.api.letsencrypt.org/directory
+  # issuer_type: "staging"
+  # letsencrypt_server: https://acme-staging-v02.api.letsencrypt.org/directory

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alexellis/ofc-bootstrap/pkg/execute"
 	"github.com/alexellis/ofc-bootstrap/pkg/ingress"
 	"github.com/alexellis/ofc-bootstrap/pkg/stack"
+	"github.com/alexellis/ofc-bootstrap/pkg/tls"
 	"github.com/alexellis/ofc-bootstrap/pkg/types"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -189,6 +190,13 @@ func process(plan types.Plan) error {
 		ingressErr := ingress.Apply(plan)
 		if ingressErr != nil {
 			log.Println(ingressErr)
+		}
+
+		if plan.TLS {
+			tlsErr := tls.Apply(plan)
+			if tlsErr != nil {
+				log.Println(tlsErr)
+			}
 		}
 
 		fmt.Println("Creating stack.yml")

--- a/pkg/execute/exec.go
+++ b/pkg/execute/exec.go
@@ -39,8 +39,6 @@ func (et ExecTask) Execute() (ExecResult, error) {
 			parts := strings.Split(et.Command, " ")
 			command := parts[0]
 			args := parts[1:]
-			fmt.Println("c", command)
-			fmt.Println("a", args)
 			cmd = exec.Command(command, args...)
 
 		} else {

--- a/pkg/ingress/ingress_test.go
+++ b/pkg/ingress/ingress_test.go
@@ -1,0 +1,29 @@
+package ingress
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_applyTemplateWithTLS(t *testing.T) {
+	templateValues := IngressTemplate{
+		RootDomain: "test.com",
+		TLS:        true,
+	}
+
+	templateFileName := "../../templates/k8s/ingress.yml"
+
+	generatedValue, err := applyTemplate(templateFileName, templateValues)
+	want := "tls"
+
+	if err != nil {
+		t.Errorf("expected no error generating template, but got %s", err.Error())
+		t.Fail()
+		return
+	}
+
+	if strings.Contains(string(generatedValue), want) == false {
+		t.Errorf("want generated value to contain: %q, generated was: %q", want, string(generatedValue))
+		t.Fail()
+	}
+}

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -54,14 +54,16 @@ func Apply(plan types.Plan) error {
 		return dashboardConfigErr
 	}
 
-	ofAuthDepErr := generateTemplate("of-auth-dep", plan, authConfig{
-		RootDomain:   plan.RootDomain,
-		ClientId:     plan.OAuth.ClientId,
-		ClientSecret: plan.OAuth.ClientSecret,
-		Scheme:       scheme,
-	})
-	if ofAuthDepErr != nil {
-		return ofAuthDepErr
+	if plan.EnableOAuth {
+		ofAuthDepErr := generateTemplate("of-auth-dep", plan, authConfig{
+			RootDomain:   plan.RootDomain,
+			ClientId:     plan.OAuth.ClientId,
+			ClientSecret: plan.OAuth.ClientSecret,
+			Scheme:       scheme,
+		})
+		if ofAuthDepErr != nil {
+			return ofAuthDepErr
+		}
 	}
 
 	return nil

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -1,0 +1,110 @@
+package tls
+
+import (
+	"html/template"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/alexellis/ofc-bootstrap/pkg/execute"
+	"github.com/alexellis/ofc-bootstrap/pkg/types"
+)
+
+type TlsTemplate struct {
+	RootDomain        string
+	Email             string
+	DNSService        string
+	ProjectID         string
+	IssuerType        string
+	LetsencryptServer string
+	Region            string
+	AccessKeyID       string
+}
+
+var tlsTemplatesPath = "templates/k8s/tls/"
+
+func Apply(plan types.Plan) error {
+
+	tlsTemplatesList, _ := listTLSTemplates()
+	tlsTemplate := TlsTemplate{
+		RootDomain:        plan.RootDomain,
+		Email:             plan.TLSConfig.Email,
+		DNSService:        plan.TLSConfig.DNSService,
+		ProjectID:         plan.TLSConfig.ProjectID,
+		IssuerType:        plan.TLSConfig.IssuerType,
+		LetsencryptServer: plan.TLSConfig.LetsencryptServer,
+		Region:            plan.TLSConfig.Region,
+		AccessKeyID:       plan.TLSConfig.AccessKeyID,
+	}
+	for _, template := range tlsTemplatesList {
+		tempFilePath, tlsTemplateErr := generateTemplate(template, tlsTemplate)
+		if tlsTemplateErr != nil {
+			return tlsTemplateErr
+		}
+
+		applyErr := applyTemplate(tempFilePath)
+		if applyErr != nil {
+			return applyErr
+		}
+	}
+
+	return nil
+}
+
+func listTLSTemplates() ([]string, error) {
+	file, err := os.Open(tlsTemplatesPath)
+
+	if err != nil {
+		log.Fatalf("failed opening directory: %s, %s", tlsTemplatesPath, err)
+		return nil, err
+	}
+	defer file.Close()
+
+	list, _ := file.Readdirnames(0)
+	if err != nil {
+		log.Fatalf("failed reading filenames in directory %s, %s", tlsTemplatesPath, err)
+		return nil, err
+	}
+	return list, nil
+}
+
+func generateTemplate(fileName string, tlsTemplate TlsTemplate) (string, error) {
+
+	data, err := ioutil.ReadFile(tlsTemplatesPath + fileName)
+	if err != nil {
+		return "", err
+	}
+
+	t := template.Must(template.New(fileName).Parse(string(data)))
+	tempFilePath := "tmp/generated-tls-" + fileName
+	file, fileErr := os.Create(tempFilePath)
+	if fileErr != nil {
+		return "", fileErr
+	}
+	defer file.Close()
+
+	executeErr := t.Execute(file, tlsTemplate)
+
+	if executeErr != nil {
+		return "", executeErr
+	}
+
+	return tempFilePath, nil
+}
+
+func applyTemplate(tempFilePath string) error {
+
+	execTask := execute.ExecTask{
+		Command: "kubectl apply -f " + tempFilePath,
+		Shell:   false,
+	}
+
+	execRes, execErr := execTask.Execute()
+	if execErr != nil {
+		return execErr
+	}
+
+	log.Println(execRes.Stdout)
+
+	return nil
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -15,6 +15,7 @@ type Plan struct {
 	TLS           bool                     `yaml:"tls"`
 	OAuth         OAuth                    `yaml:"oauth"`
 	EnableOAuth   bool                     `yaml:"enable_oauth"`
+	TLSConfig     TLSConfig                `yaml:"tls_config"`
 }
 
 type KeyValueTuple struct {
@@ -54,4 +55,14 @@ type Github struct {
 type OAuth struct {
 	ClientId     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`
+}
+
+type TLSConfig struct {
+	Email             string `yaml:"email"`
+	DNSService        string `yaml:"dns_service"`
+	ProjectID         string `yaml:"project_id"`
+	IssuerType        string `yaml:"issuer_type"`
+	LetsencryptServer string `yaml:"letsencrypt_server"`
+	Region            string `yaml:"region"`
+	AccessKeyID       string `yaml:"access_key_id"`
 }

--- a/templates/k8s/ingress-wildcard.yml
+++ b/templates/k8s/ingress-wildcard.yml
@@ -6,10 +6,12 @@ metadata:
   namespace: openfaas
   annotations:
     certmanager.k8s.io/acme-challenge-type: dns01
-    certmanager.k8s.io/acme-dns01-provider: clouddns
+    certmanager.k8s.io/acme-dns01-provider: {{.DNSService}}
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: "nginx"
-    certmanager.k8s.io/cluster-issuer: "letsencrypt-prod"
+    certmanager.k8s.io/cluster-issuer: letsencrypt-{{.IssuerType}}
+    nginx.ingress.kubernetes.io/limit-connections: "20"
+    nginx.ingress.kubernetes.io/limit-rpm: "600"
   labels:
     app: faas-netesd
 spec:
@@ -17,7 +19,7 @@ spec:
   tls:
   - hosts:
     - '*.{{.RootDomain}}'
-    secretName: o6s-com-tls
+    secretName: wildcard-{{.RootDomain}}-cert
   {{ end }}
   rules:
   - host: '*.{{.RootDomain}}'

--- a/templates/k8s/ingress.yml
+++ b/templates/k8s/ingress.yml
@@ -6,10 +6,12 @@ metadata:
   namespace: openfaas
   annotations:
     certmanager.k8s.io/acme-challenge-type: dns01
-    certmanager.k8s.io/acme-dns01-provider: clouddns
+    certmanager.k8s.io/acme-dns01-provider: {{.DNSService}}
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: "nginx"
-    certmanager.k8s.io/cluster-issuer: "letsencrypt-prod"
+    certmanager.k8s.io/cluster-issuer: letsencrypt-{{.IssuerType}}
+    nginx.ingress.kubernetes.io/limit-connections: "20"
+    nginx.ingress.kubernetes.io/limit-rpm: "600"
   labels:
     app: faas-netesd
 spec:
@@ -17,7 +19,7 @@ spec:
   tls:
   - hosts:
     - auth.system.{{.RootDomain}}
-    secretName: auth-system-o6s-com-tls
+    secretName: auth-system-{{.RootDomain}}-cert
   {{ end }}
   rules:
   - host: auth.system.{{.RootDomain}}

--- a/templates/k8s/tls/auth-domain-cert.yml
+++ b/templates/k8s/tls/auth-domain-cert.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: auth-system-{{.RootDomain}}
+  namespace: openfaas
+spec:
+  secretName: auth-system-{{.RootDomain}}-cert
+  issuerRef:
+    name: letsencrypt-{{.IssuerType}}
+    kind: ClusterIssuer
+  commonName: 'auth.system.{{.RootDomain}}'
+  dnsNames:
+  - 'auth.system.{{.RootDomain}}'
+  acme:
+    config:
+    - dns01:
+        ingressClass: nginx
+        provider: {{.DNSService}}
+      domains:
+      - auth.system.{{.RootDomain}}

--- a/templates/k8s/tls/issuer.yml
+++ b/templates/k8s/tls/issuer.yml
@@ -1,0 +1,28 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-{{.IssuerType}}
+  namespace: openfaas
+spec:
+  acme:
+    server: "{{.LetsencryptServer}}"
+    email: "{{.Email}}"
+    privateKeySecretRef:
+      name: letsencrypt-{{.IssuerType}}
+    dns01:
+      providers:
+      - name: {{.DNSService}}
+        {{.DNSService}}:
+          {{ if eq .DNSService "clouddns" }}
+          serviceAccountSecretRef:
+            name: "{{.DNSService}}-service-account"
+            key: service-account.json
+          project: "{{.ProjectID}}"
+          {{else if eq .DNSService "route53" }}
+          region: {{.Region}}
+          # optional if ambient credentials are available; see ambient credentials documentation
+          accessKeyID: {{.AccessKeyID}}
+          secretAccessKeySecretRef:
+            name: "{{.DNSService}}-credentials-secret"
+            key: secret-access-key
+          {{ end }}

--- a/templates/k8s/tls/wildcard-domain-cert.yml
+++ b/templates/k8s/tls/wildcard-domain-cert.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: wildcard-{{.RootDomain}}
+  namespace: openfaas
+spec:
+  secretName: wildcard-{{.RootDomain}}-cert
+  issuerRef:
+    name: letsencrypt-{{.IssuerType}}
+    kind: ClusterIssuer
+  commonName: '*.{{.RootDomain}}'
+  dnsNames:
+  - '*.{{.RootDomain}}'
+  acme:
+    config:
+    - dns01:
+        ingressClass: nginx
+        provider: {{.DNSService}}
+      domains:
+      - "*.{{.RootDomain}}"


### PR DESCRIPTION
This adds ClusterIssuer optional for production or staging and for Google Cloud DNS or Amazon Route 53 and both wildcard and static domain certificates

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Closes #23 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

https://system.ivfaas.info/dashboard/ivanayov
<img width="1295" alt="screen shot 2019-01-21 at 19 47 41" src="https://user-images.githubusercontent.com/4160133/51491688-cd2cd980-1db7-11e9-95cb-bbf348852c73.png">

```
I0121 15:30:52.256986       1 controller.go:152] ingress-shim controller: syncing item 'openfaas/openfaas-ingress'
I0121 15:30:52.257027       1 sync.go:124] Certificate "wildcard-ivfaas.info-cert" for ingress "openfaas-ingress" already exists
I0121 15:30:52.257067       1 sync.go:127] Certificate "wildcard-ivfaas.info-cert" for ingress "openfaas-ingress" is up to date
I0121 15:30:52.257080       1 controller.go:166] ingress-shim controller: Finished processing work item "openfaas/openfaas-ingress"
E0121 15:30:52.257276       1 controller.go:186] certificates controller: Re-queuing item "openfaas/wildcard-ivfaas.info-cert" due to error processing: error getting certificate from acme server: acme: urn:ietf:params:acme:error:malformed: Order's status ("valid") is not acceptable for finalization
I0121 15:30:52.388351       1 issue.go:104] successfully obtained certificate: cn="*.ivfaas.info" altNames=[*.ivfaas.info] url="https://acme-staging-v02.api.letsencrypt.org/acme/order/7946776/20654277"
I0121 15:30:52.401740       1 sync.go:285] Certificate issued successfully
I0121 15:30:52.401775       1 helpers.go:188] Found status change for Certificate "wildcard-ivfaas.info" condition "Ready": "False" -> "True"; setting lastTransitionTime to 2019-01-21 15:30:52.401771 +0000 UTC m=+176.664640843
I0121 15:30:52.401965       1 sync.go:191] Certificate openfaas/wildcard-ivfaas.info scheduled for renewal in 1438 hours
I0121 15:30:52.414041       1 controller.go:191] certificates controller: Finished processing work item "openfaas/wildcard-ivfaas.info"
I0121 15:30:53.362893       1 issue.go:104] successfully obtained certificate: cn="auth.system.ivfaas.info" altNames=[auth.system.ivfaas.info] url="https://acme-staging-v02.api.letsencrypt.org/acme/order/7946776/20654278"
I0121 15:30:53.396289       1 sync.go:285] Certificate issued successfully
I0121 15:30:53.418579       1 helpers.go:188] Found status change for Certificate "auth-system-ivfaas.info" condition "Ready": "False" -> "True"; setting lastTransitionTime to 2019-01-21 15:30:53.418530507 +0000 UTC m=+177.681400371
I0121 15:30:53.539186       1 sync.go:191] Certificate openfaas/auth-system-ivfaas.info scheduled for renewal in 1438 hours
I0121 15:30:53.624902       1 controller.go:191] certificates controller: Finished processing work item "openfaas/auth-system-ivfaas.info"
I0121 15:30:55.643603       1 controller.go:177] certificates controller: syncing item 'openfaas/auth-system-ivfaas.info'
I0121 15:30:55.644137       1 sync.go:191] Certificate openfaas/auth-system-ivfaas.info scheduled for renewal in 1438 hours
I0121 15:30:55.644179       1 controller.go:191] certificates controller: Finished processing work item "openfaas/auth-system-ivfaas.info"
I0121 15:31:52.257296       1 controller.go:177] certificates controller: syncing item 'openfaas/wildcard-ivfaas.info-cert'
I0121 15:31:52.257957       1 sync.go:191] Certificate openfaas/wildcard-ivfaas.info-cert scheduled for renewal in 1438 hours
I0121 15:31:52.258010       1 controller.go:191] certificates controller: Finished processing work item "openfaas/wildcard-ivfaas.info-cert"
I0121 15:31:52.411685       1 controller.go:177] certificates controller: syncing item 'openfaas/wildcard-ivfaas.info'
I0121 15:31:52.412070       1 sync.go:191] Certificate openfaas/wildcard-ivfaas.info scheduled for renewal in 1438 hours
I0121 15:31:52.412108       1 controller.go:191] certificates controller: Finished processing work item "openfaas/wildcard-ivfaas.info"
```

Route53:
<img width="1536" alt="screen shot 2019-01-22 at 14 14 30" src="https://user-images.githubusercontent.com/4160133/51540240-a2499080-1e5e-11e9-8524-6514d3f72261.png">

<img width="1548" alt="screen shot 2019-01-22 at 14 14 53" src="https://user-images.githubusercontent.com/4160133/51540248-a5dd1780-1e5e-11e9-825f-eb646998b896.png">

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md - TODO
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests - TODO