### PR TITLE
Removing only necessary CRDs instead of all from kube-system

### DIFF
--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -2,7 +2,7 @@
 
 helm delete --purge cert-manager nginxingress openfaas cloud-minio
 kubectl delete ns openfaas openfaas-fn
-kubectl delete crd -n kube-system --all
+kubectl delete crd sealedsecrets.bitnami.com
 kubectl delete deploy/sealed-secrets-controller -n kube-system
 kubectl delete deploy/tiller-deploy -n kube-system
 kubectl delete sa/tiller -n kube-system


### PR DESCRIPTION

Closes: https://github.com/alexellis/ofc-bootstrap/issues/31

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description
Because helm is deleting CRDS from cert-manager the only ones
which we need to remove during resetting process
is sealedsecrets.bitnami.coms

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

