### PR TITLE
Add both staging and production issuers

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,30 @@ Configure or comment out as required in the relevant section.
 
 You should also set up the corresponding DNS A records.
 
+In order to enable TLS, edit the following configuration:
+
+* Set `tls: true`
+* Choose between `issuer_type: "prod"` or `issuer_type: "staging"`
+* Choose between DNS Service `route53` or `clouddns` and update your service data
+* Go to `# DNS Service Account secret` and choose the same service
+
+If you need to test in Staging and then go to Production without resetting the cluster:
+* Use `issuer_type: "staging"`
+* Run ofc-bootstrap with the instructions bellow
+* Once you want to switch to Production run
+```
+sed -i '' s/letsencrypt-staging/letsencrypt-prod/g ./tmp/generated-ingress-ingress-wildcard.yaml
+kubectl apply -f ./tmp/generated-ingress-ingress-wildcard.yaml
+sed -i '' s/letsencrypt-staging/letsencrypt-prod/g ./tmp/generated-ingress-ingress.yaml
+kubectl apply -f ./tmp/generated-ingress-ingress.yaml
+sed -i '' s/letsencrypt-staging/letsencrypt-prod/g ./tmp/generated-tls-auth-domain-cert.yml
+kubectl apply -f ./tmp/generated-tls-auth-domain-cert.yml
+sed -i '' s/letsencrypt-staging/letsencrypt-prod/g ./tmp/generated-tls-wildcard-domain-cert.yml
+kubectl apply -f ./tmp/generated-tls-wildcard-domain-cert.yml
+
+kubectl delete certificates --all  -n openfaas
+```
+
 ### Run the Bootstrapper
 
 ```bash

--- a/init.yaml
+++ b/init.yaml
@@ -97,6 +97,9 @@ enable_oauth: false
 ## TLS
 tls: false
 tls_config:
+  issuer_type: "prod"
+  # issuer_type: "staging"
+
   ## Select DNS web service between Amazon Route 53 (route53) and Google Cloud DNS (clouddns)
   # by uncommenting the required option
   dns_service: route53
@@ -107,7 +110,3 @@ tls_config:
   # project_id: "my-openfaas-cloud"
 
   email: "email@domain"
-  issuer_type: "prod"
-  letsencrypt_server: https://acme-v02.api.letsencrypt.org/directory
-  # issuer_type: "staging"
-  # letsencrypt_server: https://acme-staging-v02.api.letsencrypt.org/directory

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -11,14 +11,13 @@ import (
 )
 
 type TlsTemplate struct {
-	RootDomain        string
-	Email             string
-	DNSService        string
-	ProjectID         string
-	IssuerType        string
-	LetsencryptServer string
-	Region            string
-	AccessKeyID       string
+	RootDomain  string
+	Email       string
+	DNSService  string
+	ProjectID   string
+	IssuerType  string
+	Region      string
+	AccessKeyID string
 }
 
 var tlsTemplatesPath = "templates/k8s/tls/"
@@ -27,14 +26,13 @@ func Apply(plan types.Plan) error {
 
 	tlsTemplatesList, _ := listTLSTemplates()
 	tlsTemplate := TlsTemplate{
-		RootDomain:        plan.RootDomain,
-		Email:             plan.TLSConfig.Email,
-		DNSService:        plan.TLSConfig.DNSService,
-		ProjectID:         plan.TLSConfig.ProjectID,
-		IssuerType:        plan.TLSConfig.IssuerType,
-		LetsencryptServer: plan.TLSConfig.LetsencryptServer,
-		Region:            plan.TLSConfig.Region,
-		AccessKeyID:       plan.TLSConfig.AccessKeyID,
+		RootDomain:  plan.RootDomain,
+		Email:       plan.TLSConfig.Email,
+		DNSService:  plan.TLSConfig.DNSService,
+		ProjectID:   plan.TLSConfig.ProjectID,
+		IssuerType:  plan.TLSConfig.IssuerType,
+		Region:      plan.TLSConfig.Region,
+		AccessKeyID: plan.TLSConfig.AccessKeyID,
 	}
 	for _, template := range tlsTemplatesList {
 		tempFilePath, tlsTemplateErr := generateTemplate(template, tlsTemplate)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -58,11 +58,10 @@ type OAuth struct {
 }
 
 type TLSConfig struct {
-	Email             string `yaml:"email"`
-	DNSService        string `yaml:"dns_service"`
-	ProjectID         string `yaml:"project_id"`
-	IssuerType        string `yaml:"issuer_type"`
-	LetsencryptServer string `yaml:"letsencrypt_server"`
-	Region            string `yaml:"region"`
-	AccessKeyID       string `yaml:"access_key_id"`
+	Email       string `yaml:"email"`
+	DNSService  string `yaml:"dns_service"`
+	ProjectID   string `yaml:"project_id"`
+	IssuerType  string `yaml:"issuer_type"`
+	Region      string `yaml:"region"`
+	AccessKeyID string `yaml:"access_key_id"`
 }

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -7,5 +7,6 @@ kubectl delete deploy/sealed-secrets-controller -n kube-system
 kubectl delete deploy/tiller-deploy -n kube-system
 kubectl delete sa/tiller -n kube-system
 kubectl delete clusterrolebinding/tiller -n kube-system
+kubectl delete certificates --all  -n openfaas
 
 rm -rf ./tmp

--- a/templates/k8s/tls/issuer-prod.yml
+++ b/templates/k8s/tls/issuer-prod.yml
@@ -1,0 +1,28 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+  namespace: openfaas
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: "{{.Email}}"
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    dns01:
+      providers:
+      - name: {{.DNSService}}
+        {{.DNSService}}:
+          {{ if eq .DNSService "clouddns" }}
+          serviceAccountSecretRef:
+            name: "{{.DNSService}}-service-account"
+            key: service-account.json
+          project: "{{.ProjectID}}"
+          {{else if eq .DNSService "route53" }}
+          region: {{.Region}}
+          # optional if ambient credentials are available; see ambient credentials documentation
+          accessKeyID: {{.AccessKeyID}}
+          secretAccessKeySecretRef:
+            name: "{{.DNSService}}-credentials-secret"
+            key: secret-access-key
+          {{ end }}

--- a/templates/k8s/tls/issuer-staging.yml
+++ b/templates/k8s/tls/issuer-staging.yml
@@ -1,14 +1,14 @@
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: ClusterIssuer
 metadata:
-  name: letsencrypt-{{.IssuerType}}
+  name: letsencrypt-staging
   namespace: openfaas
 spec:
   acme:
-    server: "{{.LetsencryptServer}}"
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
     email: "{{.Email}}"
     privateKeySecretRef:
-      name: letsencrypt-{{.IssuerType}}
+      name: letsencrypt-staging
     dns01:
       providers:
       - name: {{.DNSService}}


### PR DESCRIPTION
With this change both `issuer-staging` and `issuer-prod` will be
deployed. This allows switching to production without reseting the
whole cluster by simply editing and applying generated yml files
for ingress and certificates and deleting the old certificates.

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deploying with TLS enabled with `letsencrypt-staging`, then editing ingress and certificates to use `letsencrypt-prod`, opening the dashboard and checking the new generated certificates:
```
$ kubectl describe certificate wildcard-ivfaas.me.uk-cert -n openfaas
Name:         wildcard-ivfaas.me.uk-cert
............
  Issuer Ref:
    Kind:       ClusterIssuer
    Name:       letsencrypt-prod
  Secret Name:  wildcard-ivfaas.me.uk-cert
Status:
Events:  <none>
```

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
