### PR TITLE
Template `customers_url` for of-auth

### DIFF
--- a/pkg/stack/stack_test.go
+++ b/pkg/stack/stack_test.go
@@ -1,0 +1,33 @@
+package stack
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_applyTemplateWithAuth(t *testing.T) {
+
+	templateValues := authConfig{
+		ClientId:     "7gbfgsbh9gbgbg786gs7bs",
+		CustomersURL: "https://raw.githubusercontent.com/test/path/CUSTOMERS",
+		Scheme:       "http",
+	}
+
+	templateFileName := "../../templates/of-auth-dep.yml"
+
+	generatedValue, err := applyTemplate(templateFileName, templateValues)
+
+	if err != nil {
+		t.Errorf("expected no error generating template, but got %s", err.Error())
+		t.Fail()
+		return
+	}
+
+	values := []string{"7gbfgsbh9gbgbg786gs7bs", "https://raw.githubusercontent.com/test/path/CUSTOMERS"}
+	for _, want := range values {
+		if strings.Contains(string(generatedValue), want) == false {
+			t.Errorf("want generated value to contain: %q, generated was: %q", want, string(generatedValue))
+			t.Fail()
+		}
+	}
+}

--- a/templates/of-auth-dep.yml
+++ b/templates/of-auth-dep.yml
@@ -59,7 +59,7 @@ spec:
 
 # This is a default and can be overriden
           - name: customers_url
-            value: "https://raw.githubusercontent.com/openfaas/openfaas-cloud/master/CUSTOMERS"
+            value: "{{.CustomersURL}}"
 
           - name: write_debug
             value: "false"


### PR DESCRIPTION
The `customers_url` value was hardcoded in `of-auth-dep.yml` with
the community cluster list, which was causing users, not listed
in the CUSTOMERS file configured in `init.yml` to be able to
open the dashboard for an on-prem OpenFaaS Cloud instance

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Closes #33 

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md N/A
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests N/A
