### PR TITLE
Read client_secret from a secret in of-auth-dep

### DIFF
--- a/init.yaml
+++ b/init.yaml
@@ -86,7 +86,6 @@ github:
 ## Populate from OAuth App
 oauth:
   client_id: 914f3fb036ce9cd774
-  client_secret: fb58e886977efbece9cd77452be27e9
 
 ### Users allowed to access your OpenFaaS Cloud
 customers_url: "https://raw.githubusercontent.com/openfaas/openfaas-cloud/master/CUSTOMERS"

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -16,10 +16,9 @@ type gatewayConfig struct {
 }
 
 type authConfig struct {
-	RootDomain   string
-	ClientId     string
-	ClientSecret string
-	Scheme       string
+	RootDomain string
+	ClientId   string
+	Scheme     string
 }
 
 // Apply creates `templates/gateway_config.yml` to be referenced by stack.yml
@@ -56,10 +55,9 @@ func Apply(plan types.Plan) error {
 
 	if plan.EnableOAuth {
 		ofAuthDepErr := generateTemplate("of-auth-dep", plan, authConfig{
-			RootDomain:   plan.RootDomain,
-			ClientId:     plan.OAuth.ClientId,
-			ClientSecret: plan.OAuth.ClientSecret,
-			Scheme:       scheme,
+			RootDomain: plan.RootDomain,
+			ClientId:   plan.OAuth.ClientId,
+			Scheme:     scheme,
 		})
 		if ofAuthDepErr != nil {
 			return ofAuthDepErr

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -53,8 +53,7 @@ type Github struct {
 }
 
 type OAuth struct {
-	ClientId     string `yaml:"client_id"`
-	ClientSecret string `yaml:"client_secret"`
+	ClientId string `yaml:"client_id"`
 }
 
 type TLSConfig struct {

--- a/templates/of-auth-dep.yml
+++ b/templates/of-auth-dep.yml
@@ -29,9 +29,15 @@ spec:
         env:
           - name: port
             value: "8080"
+          - name: oauth_client_secret_path
+            value: "/var/secrets/of-client-secret/of-client-secret"
+          - name: public_key_path
+            value: "/var/secrets/public/key.pub"
+          - name: private_key_path
+            value: "/var/secrets/private/key"
 # Update for your configuration:
-          - name: client_secret
-            value: "{{.ClientSecret}}"
+          - name: client_secret # this can also be provided via a secret named of-client-secret
+            value: ""
           - name: client_id
             value: "{{.ClientId}}"
           - name: oauth_provider_base_url
@@ -49,13 +55,6 @@ spec:
             value: "{{.Scheme}}://auth.system.{{.RootDomain}}"
           - name: cookie_root_domain
             value: ".{{.RootDomain}}"
-
-          - name: public_key_path
-            value: "/var/secrets/public/key.pub"
-          - name: private_key_path
-            value: "/var/secrets/private/key"
-          - name: of-client-secret
-            value: "/var/secrets/of-client-secret/of-client-secret"
 
 # This is a default and can be overriden
           - name: customers_url


### PR DESCRIPTION
Before `client_secret` configuration was duplicated in init.yml
once for creating `of-client-secret` and again for configuring
`oauth`, which can be confusing for the user. Now it's not
templated in of-auth-dep.yml, but the value is taken from the
secret instead

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Closes #36 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on http://system.ivana-web.xyz/dashboard/ivanayov 

<img width="1467" alt="screen shot 2019-01-23 at 19 43 11" src="https://user-images.githubusercontent.com/4160133/51626015-43ac1180-1f47-11e9-935f-2eacab2826b9.png">

<img width="1552" alt="screen shot 2019-01-23 at 19 43 25" src="https://user-images.githubusercontent.com/4160133/51626024-46a70200-1f47-11e9-922a-fc9592ea8063.png">

<img width="1626" alt="screen shot 2019-01-23 at 19 43 42" src="https://user-images.githubusercontent.com/4160133/51626036-4ad31f80-1f47-11e9-9d78-5e666987cad3.png">

## Checklist:

I have:

- [ ] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
