### PR TITLE
Add build scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Build stage
+FROM golang:1.10 as builder
+
+WORKDIR /usr/bin/
+RUN curl -sLSf https://raw.githubusercontent.com/alexellis/license-check/master/get.sh | sh
+
+WORKDIR /go/src/github.com/openfaas-incubator/ofc-bootstrap
+COPY . .
+
+# Run a gofmt and exclude all vendored code.
+RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
+
+RUN /usr/bin/license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Author(s)"
+RUN go test $(go list ./... | grep -v /vendor/ | grep -v /template/|grep -v /build/) -cover \
+ && VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///') \
+ && GIT_COMMIT=$(git rev-list -1 HEAD) \
+ && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w \
+    -X github.com/openfaas-incubator/ofc-bootstrap/version.GitCommit=${GIT_COMMIT} \
+    -X github.com/openfaas-incubator/ofc-bootstrap/version.Version=${VERSION}" \
+    -a -installsuffix cgo -o ofc-bootstrap
+
+# Release stage
+FROM alpine:3.8
+
+RUN apk --no-cache add ca-certificates git
+
+WORKDIR /root/
+
+COPY --from=builder /go/src/github.com/openfaas-incubator/ofc-bootstrap/ofc-bootstrap               /usr/bin/
+
+ENV PATH=$PATH:/usr/bin/
+
+CMD ["ofc-bootstrap"]

--- a/Dockerfile.redist
+++ b/Dockerfile.redist
@@ -1,0 +1,44 @@
+# Build stage
+FROM golang:1.10 as builder
+
+WORKDIR /usr/bin/
+RUN curl -sLSf https://raw.githubusercontent.com/alexellis/license-check/master/get.sh | sh
+
+WORKDIR /go/src/github.com/openfaas-incubator/ofc-bootstrap
+COPY . .
+
+# Run a gofmt and exclude all vendored code.
+RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
+
+
+RUN /usr/bin/license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Author(s)" \
+ && go test $(go list ./... | grep -v /vendor/ | grep -v /template/|grep -v /build/) -cover \
+ && VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///') \
+ && GIT_COMMIT=$(git rev-list -1 HEAD) \
+ && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w \
+        -X github.com/openfaas-incubator/ofc-bootstrap/version.GitCommit=${GIT_COMMIT} \
+        -X github.com/openfaas-incubator/ofc-bootstrap/version.Version=${VERSION}" \
+        -a -installsuffix cgo -o ofc-bootstrap \
+ && CGO_ENABLED=0 GOOS=darwin go build --ldflags "-s -w \
+        -X github.com/openfaas-incubator/ofc-bootstrap/version.GitCommit=${GIT_COMMIT} \
+        -X github.com/openfaas-incubator/ofc-bootstrap/version.Version=${VERSION}" \
+        -a -installsuffix cgo -o ofc-bootstrap-darwin \
+ && CGO_ENABLED=0 GOOS=windows go build --ldflags "-s -w \
+        -X github.com/openfaas-incubator/ofc-bootstrap/version.GitCommit=${GIT_COMMIT} \
+        -X github.com/openfaas-incubator/ofc-bootstrap/version.Version=${VERSION}" \
+        -a -installsuffix cgo -o ofc-bootstrap.exe
+
+# Release stage
+FROM alpine:3.8
+
+RUN apk --no-cache add ca-certificates git
+
+WORKDIR /root/
+
+COPY --from=builder /go/src/github.com/openfaas-incubator/ofc-bootstrap/ofc-bootstrap                .
+COPY --from=builder /go/src/github.com/openfaas-incubator/ofc-bootstrap/ofc-bootstrap-darwin         .
+COPY --from=builder /go/src/github.com/openfaas-incubator/ofc-bootstrap/ofc-bootstrap.exe            .
+
+ENV PATH=$PATH:/root/
+
+CMD ["ofc-bootstrap"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016-2017 Alex Ellis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,18 @@
+
+GO_FILES?=$$(find . -name '*.go' |grep -v vendor)
+TAG?=latest
+
 .PHONY: ci
 
 install-ci:
 	./hack/install-ci.sh
 ci:
 	./hack/ci.sh
+
+.PHONY: build
+build:
+	./build.sh
+
+.PHONY: dist
+dist:
+	./build_redist.sh

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+export eTAG="latest-dev"
+echo $1
+if [ $1 ] ; then
+  eTAG=$1
+fi
+
+echo Building openfaas/ofc-bootstrap:$eTAG
+
+docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -t openfaas/ofc-bootstrap:$eTAG . && \
+ docker create --name ofc-bootstrap openfaas/ofc-bootstrap:$eTAG && \
+ docker cp ofc-bootstrap:/usr/bin/ofc-bootstrap . && \
+ docker rm -f ofc-bootstrap

--- a/build_redist.sh
+++ b/build_redist.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+export eTAG="latest-dev"
+echo $1
+if [ $1 ] ; then
+  eTAG=$1
+fi
+
+docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -t openfaas/ofc-bootstrap:$eTAG . -f Dockerfile.redist && \
+ docker create --name ofc-bootstrap openfaas/ofc-bootstrap:$eTAG && \
+ docker cp ofc-bootstrap:/root/ofc-bootstrap . && \
+ docker cp ofc-bootstrap:/root/ofc-bootstrap-darwin . && \
+ docker cp ofc-bootstrap:/root/ofc-bootstrap.exe . && \
+ docker rm -f ofc-bootstrap


### PR DESCRIPTION
This adds Dockerfiles for both normal and distribution builds as
well as build scripts. Creates binaries for Linux, Mac OS and
Windows. To use run `make dist`

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Closes #41 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make dist` and `make build`

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
