### PR TITLE
Read client_secret from a secret in of-auth-dep

### DIFF
--- a/init.yaml
+++ b/init.yaml
@@ -86,7 +86,6 @@ github:
 ## Populate from OAuth App
 oauth:
   client_id: 914f3fb036ce9cd774
-  client_secret: fb58e886977efbece9cd77452be27e9
 
 ### Users allowed to access your OpenFaaS Cloud
 customers_url: "https://raw.githubusercontent.com/openfaas/openfaas-cloud/master/CUSTOMERS"

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -20,7 +20,6 @@ type gatewayConfig struct {
 type authConfig struct {
 	RootDomain   string
 	ClientId     string
-	ClientSecret string
 	CustomersURL string
 	Scheme       string
 }
@@ -62,7 +61,6 @@ func Apply(plan types.Plan) error {
 		ofAuthDepErr := generateTemplate("of-auth-dep", plan, authConfig{
 			RootDomain:   plan.RootDomain,
 			ClientId:     plan.OAuth.ClientId,
-			ClientSecret: plan.OAuth.ClientSecret,
 			CustomersURL: plan.CustomersURL,
 			Scheme:       scheme,
 		})

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -54,8 +54,7 @@ type Github struct {
 }
 
 type OAuth struct {
-	ClientId     string `yaml:"client_id"`
-	ClientSecret string `yaml:"client_secret"`
+	ClientId string `yaml:"client_id"`
 }
 
 type S3 struct {

--- a/templates/of-auth-dep.yml
+++ b/templates/of-auth-dep.yml
@@ -29,9 +29,15 @@ spec:
         env:
           - name: port
             value: "8080"
+          - name: oauth_client_secret_path
+            value: "/var/secrets/of-client-secret/of-client-secret"
+          - name: public_key_path
+            value: "/var/secrets/public/key.pub"
+          - name: private_key_path
+            value: "/var/secrets/private/key"
 # Update for your configuration:
-          - name: client_secret
-            value: "{{.ClientSecret}}"
+          - name: client_secret # this can also be provided via a secret named of-client-secret
+            value: ""
           - name: client_id
             value: "{{.ClientId}}"
           - name: oauth_provider_base_url
@@ -49,13 +55,6 @@ spec:
             value: "{{.Scheme}}://auth.system.{{.RootDomain}}"
           - name: cookie_root_domain
             value: ".{{.RootDomain}}"
-
-          - name: public_key_path
-            value: "/var/secrets/public/key.pub"
-          - name: private_key_path
-            value: "/var/secrets/private/key"
-          - name: of-client-secret
-            value: "/var/secrets/of-client-secret/of-client-secret"
 
 # This is a default and can be overriden
           - name: customers_url


### PR DESCRIPTION
Follow up of #40 
Closes #33 

Before `client_secret` configuration was duplicated in init.yml
once for creating `of-client-secret` and again for configuring
`oauth`, which can be confusing for the user. Now it's not
templated in of-auth-dep.yml, but the value is taken from the
secret instead

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>
