### PR TITLE
Make of-auth test more human-readable

### DIFF
--- a/pkg/stack/stack_test.go
+++ b/pkg/stack/stack_test.go
@@ -7,9 +7,12 @@ import (
 
 func Test_applyTemplateWithAuth(t *testing.T) {
 
+	clientID := "test_oauth_app_client_id"
+	customersURL := "https://raw.githubusercontent.com/test/path/CUSTOMERS"
+
 	templateValues := authConfig{
-		ClientId:     "7gbfgsbh9gbgbg786gs7bs",
-		CustomersURL: "https://raw.githubusercontent.com/test/path/CUSTOMERS",
+		ClientId:     clientID,
+		CustomersURL: customersURL,
 		Scheme:       "http",
 	}
 
@@ -23,7 +26,7 @@ func Test_applyTemplateWithAuth(t *testing.T) {
 		return
 	}
 
-	values := []string{"7gbfgsbh9gbgbg786gs7bs", "https://raw.githubusercontent.com/test/path/CUSTOMERS"}
+	values := []string{clientID, customersURL}
 	for _, want := range values {
 		if strings.Contains(string(generatedValue), want) == false {
 			t.Errorf("want generated value to contain: %q, generated was: %q", want, string(generatedValue))


### PR DESCRIPTION
This is a follow-up of #38 changing only a test value for OAuth
GitHub App Client ID for better readability

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Related to #33 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running `Test_applyTemplateWithAuth` form `stack_test.go`

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
