### PR TITLE
Template "slack_url" for audit trail

### DIFF
--- a/init.yaml
+++ b/init.yaml
@@ -100,6 +100,11 @@ github:
 oauth:
   client_id: 914f3fb036ce9cd774
 
+## Slack
+### You can set your own url to get an audit trail in your Slack workspace
+slack:
+  url: http://gateway.openfaas:8080/function/echo
+
 ### Users allowed to access your OpenFaaS Cloud
 #### ACL for your users, it must be a raw text file or GitHub RAW URL
 customers_url: "https://raw.githubusercontent.com/openfaas/openfaas-cloud/master/CUSTOMERS"

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -50,6 +50,12 @@ func Apply(plan types.Plan) error {
 		return githubConfigErr
 	}
 
+	if slackConfigErr := generateTemplate("slack", plan, types.Slack{
+		URL: plan.Slack.URL,
+	}); slackConfigErr != nil {
+		return slackConfigErr
+	}
+
 	dashboardConfigErr := generateTemplate("dashboard_config", plan, gatewayConfig{
 		RootDomain: plan.RootDomain, Scheme: scheme,
 	})

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -17,6 +17,7 @@ type Plan struct {
 	S3            S3                       `yaml:"s3"`
 	EnableOAuth   bool                     `yaml:"enable_oauth"`
 	TLSConfig     TLSConfig                `yaml:"tls_config"`
+	Slack         Slack                    `yaml:"slack"`
 }
 
 type KeyValueTuple struct {
@@ -51,6 +52,10 @@ type KeyValueNamespaceTuple struct {
 type Github struct {
 	AppID          string `yaml:"app_id"`
 	PrivateKeyFile string `yaml:"private_key_filename"`
+}
+
+type Slack struct {
+	URL string `yaml:"url"`
 }
 
 type OAuth struct {

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -2,6 +2,7 @@
 
 cp ./tmp/generated-gateway_config.yml ./tmp/openfaas-cloud/gateway_config.yml
 cp ./tmp/generated-github.yml ./tmp/openfaas-cloud/github.yml
+cp ./tmp/generated-slack.yml ./tmp/openfaas-cloud/slack.yml
 cp ./tmp/generated-dashboard_config.yml ./tmp/openfaas-cloud/dashboard/dashboard_config.yml
 cp ./tmp/generated-of-auth-dep.yml ./tmp/openfaas-cloud/yaml/core/of-auth-dep.yml
 

--- a/templates/slack.yml
+++ b/templates/slack.yml
@@ -1,0 +1,2 @@
+environment:
+  slack_url: "{{.URL}}"


### PR DESCRIPTION
Closes https://github.com/openfaas-incubator/ofc-bootstrap/issues/24

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have deployed local OFC cluster using KinD with modified slack url

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

