### PR TITLE
Install SealedSecrets from chart

### DIFF
--- a/scripts/install-sealedsecrets.sh
+++ b/scripts/install-sealedsecrets.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-GOOS=$(go env GOOS)
-GOARCH=$(go env GOARCH)
-
 release=$(curl -sI https://github.com/bitnami-labs/sealed-secrets/releases/latest | grep Location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
 #release=$(curl --silent "https://api.github.com/repos/bitnami-labs/sealed-secrets/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
 
 echo "SealedSecrets release: $release"
 
-kubectl create -f https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/sealedsecret-crd.yaml
+helm del --purge ofc-bootstrap
+kubectl delete customresourcedefinition sealedsecrets.bitnami.com
 
-kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/controller.yaml
+helm install --namespace kube-system --name ofc-bootstrap stable/sealed-secrets


### PR DESCRIPTION
SealedSecrets are now installed with helm chart that is already
available

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Resolves #55 
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
WIP: needs implementing importing secrets 

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md TODO
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests N/A

