### PR TITLE
Initial commit for DO provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,18 +122,32 @@ In order to enable TLS, edit the following configuration:
 If you need to test in Staging and then go to Production without resetting the cluster:
 * Use `issuer_type: "staging"`
 * Run ofc-bootstrap with the instructions bellow
-* Once you want to switch to Production run
-```
-sed -i '' s/letsencrypt-staging/letsencrypt-prod/g ./tmp/generated-ingress-ingress-wildcard.yaml
-kubectl apply -f ./tmp/generated-ingress-ingress-wildcard.yaml
-sed -i '' s/letsencrypt-staging/letsencrypt-prod/g ./tmp/generated-ingress-ingress.yaml
-kubectl apply -f ./tmp/generated-ingress-ingress.yaml
-sed -i '' s/letsencrypt-staging/letsencrypt-prod/g ./tmp/generated-tls-auth-domain-cert.yml
-kubectl apply -f ./tmp/generated-tls-auth-domain-cert.yml
-sed -i '' s/letsencrypt-staging/letsencrypt-prod/g ./tmp/generated-tls-wildcard-domain-cert.yml
-kubectl apply -f ./tmp/generated-tls-wildcard-domain-cert.yml
+* Once you want to switch to the Production issuer
 
+Flush out the staging certificates and orders
+
+```sh
 kubectl delete certificates --all  -n openfaas
+kubectl delete secret -n openfaas -l="certmanager.k8s.io/certificate-name"
+kubectl delete order -n openfaas --all
+```
+
+Now update the staging references to "prod":
+
+```sh
+sed -i '' s/letsencrypt-staging/letsencrypt-prod/g ./tmp/generated-ingress-ingress-wildcard.yaml
+sed -i '' s/letsencrypt-staging/letsencrypt-prod/g ./tmp/generated-ingress-ingress.yaml
+sed -i '' s/letsencrypt-staging/letsencrypt-prod/g ./tmp/generated-tls-auth-domain-cert.yml
+sed -i '' s/letsencrypt-staging/letsencrypt-prod/g ./tmp/generated-tls-wildcard-domain-cert.yml
+```
+
+Now create the new ingress and certificates:
+
+```sh
+kubectl apply -f ./tmp/generated-ingress-ingress-wildcard.yaml
+kubectl apply -f ./tmp/generated-ingress-ingress.yaml
+kubectl apply -f ./tmp/generated-tls-auth-domain-cert.yml
+kubectl apply -f ./tmp/generated-tls-wildcard-domain-cert.yml
 ```
 
 ### Run the Bootstrapper

--- a/init.yaml
+++ b/init.yaml
@@ -69,6 +69,13 @@ secrets:
         value_from: "~/Downloads/service-account.json"
     namespace: "kube-system"
 
+  ## Use DigitalOcean
+  - name: "digitalocean-dns"
+    files:
+      - name: "access-token"
+        value_from: "~/Downloads/do-access-token"
+    namespace: "cert-manager"
+
   ## or Use Route 53
   # - name: "route53-credentials-secret"
   #   files:
@@ -128,7 +135,7 @@ enable_oauth: false
 ### your OpenFaaS Cloud.
 tls: true
 tls_config:
-  email: "email@domain"
+  email: "user@domain"
 
   # issuer_type: "prod"
   issuer_type: "staging"

--- a/init.yaml
+++ b/init.yaml
@@ -128,7 +128,6 @@ enable_oauth: false
 ### your OpenFaaS Cloud.
 tls: true
 tls_config:
-
   email: "email@domain"
 
   # issuer_type: "prod"
@@ -148,4 +147,3 @@ tls_config:
 
   ### DigitalOcean
   dns_service: digitalocean
-  digitalocean_access_token: ""

--- a/init.yaml
+++ b/init.yaml
@@ -135,7 +135,8 @@ enable_oauth: false
 ### your OpenFaaS Cloud.
 tls: true
 tls_config:
-  email: "user@domain"
+#  email: "user@domain"
+
 
   # issuer_type: "prod"
   issuer_type: "staging"

--- a/init.yaml
+++ b/init.yaml
@@ -90,7 +90,7 @@ secrets:
 registry: docker.io/ofctest/
 
 ### Your root DNS domain name, this can be a sub-domain i.e. staging.o6s.io / prod.o6s.io
-root_domain: "stag.o6s.io"
+root_domain: "myfaas.club"
 
 ## Populate from GitHub App
 github:
@@ -126,23 +126,26 @@ enable_oauth: false
 ## TLS
 ### When enabled cert-manager will be used to provision wildcard TLS certificates for
 ### your OpenFaaS Cloud.
-tls: false
+tls: true
 tls_config:
 
   email: "email@domain"
 
-  issuer_type: "prod"
-  # issuer_type: "staging"
+  # issuer_type: "prod"
+  issuer_type: "staging"
 
   ## Select DNS web service between Amazon Route 53 (route53) and Google Cloud DNS (clouddns)
   # by uncommenting the required option
 
   ### Google Cloud DNS
-  dns_service: clouddns
-  project_id: "my-openfaas-cloud"
+  # dns_service: clouddns
+  # project_id: "my-openfaas-cloud"
 
   ### AWS Route53
   # dns_service: route53
   # region: us-east-1
   # access_key_id: ASYAKIUJE8AYRQQ7DU3M
 
+  ### DigitalOcean
+  dns_service: digitalocean
+  digitalocean_access_token: ""

--- a/main.go
+++ b/main.go
@@ -134,7 +134,6 @@ func main() {
 
 func process(plan types.Plan) error {
 
-	fmt.Println(plan)
 	if plan.Orchestration == OrchestrationK8s {
 		fmt.Println("Orchestration: Kubernetes")
 	} else if plan.Orchestration == OrchestrationSwarm {
@@ -443,9 +442,8 @@ func createNamespaces() error {
 
 func createSecrets(plan types.Plan) error {
 
-	fmt.Println(plan.Secrets)
-
 	for _, secret := range plan.Secrets {
+		fmt.Printf("Creating secret: %s\n", secret.Name)
 
 		var command execute.ExecTask
 		if plan.Orchestration == OrchestrationK8s {

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -18,6 +18,8 @@ type IngressTemplate struct {
 	DNSService string
 }
 
+// Apply templates and applies any ingress records required
+// for the OpenFaaS Cloud ingress configuration
 func Apply(plan types.Plan) error {
 
 	err := apply("ingress-wildcard.yml", "ingress-wildcard", IngressTemplate{
@@ -90,7 +92,7 @@ func apply(source string, name string, ingress IngressTemplate) error {
 		return execErr
 	}
 
-	log.Println(execRes.Stdout)
+	log.Println(execRes.ExitCode, execRes.Stdout, execRes.Stderr)
 
 	return nil
 }

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -10,30 +10,35 @@ import (
 	"github.com/openfaas-incubator/ofc-bootstrap/pkg/types"
 )
 
-type TlsTemplate struct {
-	RootDomain  string
-	Email       string
-	DNSService  string
-	ProjectID   string
-	IssuerType  string
-	Region      string
-	AccessKeyID string
+// TLSTemplate TLS configuration
+type TLSTemplate struct {
+	RootDomain              string
+	Email                   string
+	DNSService              string
+	ProjectID               string
+	IssuerType              string
+	Region                  string
+	AccessKeyID             string
+	DigitalOceanAccessToken string
 }
 
 var tlsTemplatesPath = "templates/k8s/tls/"
 
+// Apply executes the plan
 func Apply(plan types.Plan) error {
 
 	tlsTemplatesList, _ := listTLSTemplates()
-	tlsTemplate := TlsTemplate{
-		RootDomain:  plan.RootDomain,
-		Email:       plan.TLSConfig.Email,
-		DNSService:  plan.TLSConfig.DNSService,
-		ProjectID:   plan.TLSConfig.ProjectID,
-		IssuerType:  plan.TLSConfig.IssuerType,
-		Region:      plan.TLSConfig.Region,
-		AccessKeyID: plan.TLSConfig.AccessKeyID,
+	tlsTemplate := TLSTemplate{
+		RootDomain:              plan.RootDomain,
+		Email:                   plan.TLSConfig.Email,
+		DNSService:              plan.TLSConfig.DNSService,
+		ProjectID:               plan.TLSConfig.ProjectID,
+		IssuerType:              plan.TLSConfig.IssuerType,
+		Region:                  plan.TLSConfig.Region,
+		AccessKeyID:             plan.TLSConfig.AccessKeyID,
+		DigitalOceanAccessToken: plan.TLSConfig.DigitalOceanAccessToken,
 	}
+
 	for _, template := range tlsTemplatesList {
 		tempFilePath, tlsTemplateErr := generateTemplate(template, tlsTemplate)
 		if tlsTemplateErr != nil {
@@ -66,7 +71,7 @@ func listTLSTemplates() ([]string, error) {
 	return list, nil
 }
 
-func generateTemplate(fileName string, tlsTemplate TlsTemplate) (string, error) {
+func generateTemplate(fileName string, tlsTemplate TLSTemplate) (string, error) {
 
 	data, err := ioutil.ReadFile(tlsTemplatesPath + fileName)
 	if err != nil {

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -97,7 +97,7 @@ func applyTemplate(tempFilePath string) error {
 		return execErr
 	}
 
-	log.Println(execRes.Stdout)
+	log.Println(execRes.ExitCode, execRes.Stdout, execRes.Stderr)
 
 	return nil
 }

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -12,31 +12,27 @@ import (
 
 // TLSTemplate TLS configuration
 type TLSTemplate struct {
-	RootDomain              string
-	Email                   string
-	DNSService              string
-	ProjectID               string
-	IssuerType              string
-	Region                  string
-	AccessKeyID             string
-	DigitalOceanAccessToken string
+	RootDomain  string
+	Email       string
+	DNSService  string
+	ProjectID   string
+	IssuerType  string
+	Region      string
+	AccessKeyID string
 }
-
-var tlsTemplatesPath = "templates/k8s/tls/"
 
 // Apply executes the plan
 func Apply(plan types.Plan) error {
 
 	tlsTemplatesList, _ := listTLSTemplates()
 	tlsTemplate := TLSTemplate{
-		RootDomain:              plan.RootDomain,
-		Email:                   plan.TLSConfig.Email,
-		DNSService:              plan.TLSConfig.DNSService,
-		ProjectID:               plan.TLSConfig.ProjectID,
-		IssuerType:              plan.TLSConfig.IssuerType,
-		Region:                  plan.TLSConfig.Region,
-		AccessKeyID:             plan.TLSConfig.AccessKeyID,
-		DigitalOceanAccessToken: plan.TLSConfig.DigitalOceanAccessToken,
+		RootDomain:  plan.RootDomain,
+		Email:       plan.TLSConfig.Email,
+		DNSService:  plan.TLSConfig.DNSService,
+		ProjectID:   plan.TLSConfig.ProjectID,
+		IssuerType:  plan.TLSConfig.IssuerType,
+		Region:      plan.TLSConfig.Region,
+		AccessKeyID: plan.TLSConfig.AccessKeyID,
 	}
 
 	for _, template := range tlsTemplatesList {
@@ -55,23 +51,17 @@ func Apply(plan types.Plan) error {
 }
 
 func listTLSTemplates() ([]string, error) {
-	file, err := os.Open(tlsTemplatesPath)
 
-	if err != nil {
-		log.Fatalf("failed opening directory: %s, %s", tlsTemplatesPath, err)
-		return nil, err
-	}
-	defer file.Close()
-
-	list, _ := file.Readdirnames(0)
-	if err != nil {
-		log.Fatalf("failed reading filenames in directory %s, %s", tlsTemplatesPath, err)
-		return nil, err
-	}
-	return list, nil
+	return []string{
+		"issuer-prod.yml",
+		"issuer-staging.yml",
+		"wildcard-domain-cert.yml",
+		"auth-domain-cert.yml",
+	}, nil
 }
 
 func generateTemplate(fileName string, tlsTemplate TLSTemplate) (string, error) {
+	tlsTemplatesPath := "templates/k8s/tls/"
 
 	data, err := ioutil.ReadFile(tlsTemplatesPath + fileName)
 	if err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -70,10 +70,11 @@ type S3 struct {
 }
 
 type TLSConfig struct {
-	Email       string `yaml:"email"`
-	DNSService  string `yaml:"dns_service"`
-	ProjectID   string `yaml:"project_id"`
-	IssuerType  string `yaml:"issuer_type"`
-	Region      string `yaml:"region"`
-	AccessKeyID string `yaml:"access_key_id"`
+	Email                   string `yaml:"email"`
+	DNSService              string `yaml:"dns_service"`
+	ProjectID               string `yaml:"project_id"`
+	IssuerType              string `yaml:"issuer_type"`
+	Region                  string `yaml:"region"`
+	AccessKeyID             string `yaml:"access_key_id"`
+	DigitalOceanAccessToken string `yaml:"digitalocean_access_token"`
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -70,11 +70,10 @@ type S3 struct {
 }
 
 type TLSConfig struct {
-	Email                   string `yaml:"email"`
-	DNSService              string `yaml:"dns_service"`
-	ProjectID               string `yaml:"project_id"`
-	IssuerType              string `yaml:"issuer_type"`
-	Region                  string `yaml:"region"`
-	AccessKeyID             string `yaml:"access_key_id"`
-	DigitalOceanAccessToken string `yaml:"digitalocean_access_token"`
+	Email       string `yaml:"email"`
+	DNSService  string `yaml:"dns_service"`
+	ProjectID   string `yaml:"project_id"`
+	IssuerType  string `yaml:"issuer_type"`
+	Region      string `yaml:"region"`
+	AccessKeyID string `yaml:"access_key_id"`
 }

--- a/scripts/create-namespaces.sh
+++ b/scripts/create-namespaces.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
 kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
+
+kubectl create namespace cert-manager
+kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+
+kubectl get namespaces

--- a/scripts/get-cert-manager.sh
+++ b/scripts/get-cert-manager.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# cert-manager is ready for CRD objects when this condition is "True"
+CERT_READY=$(kubectl get cert/cert-manager-webhook-webhook-tls -n  cert-manager -o jsonpath="{.status.conditions[0].status}")
+WEBHOOK_READY=$(kubectl get deploy/cert-manager-webhook -n cert-manager -o jsonpath="{.status.conditions[0].status}")
+
+if [ "$CERT_READY" = "True" ]
+then
+    if [ "$WEBHOOK_READY" = "True" ]
+    then
+        echo -n True
+    fi
+fi

--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -3,8 +3,11 @@
 kubectl apply \
     -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
 
+kubectl create namespace cert-manager
+kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+
 helm install \
     --name cert-manager \
-    --namespace kube-system \
+    --namespace cert-manager \
     --version v0.6.0 \
     stable/cert-manager

--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -3,9 +3,6 @@
 kubectl apply \
     -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
 
-kubectl create namespace cert-manager
-kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
-
 helm install \
     --name cert-manager \
     --namespace cert-manager \

--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+kubectl apply \
+    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
+
 helm install \
     --name cert-manager \
     --namespace kube-system \
-    --version v0.4.0 \
+    --version v0.6.0 \
     stable/cert-manager

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -2,13 +2,14 @@
 
 helm delete --purge cert-manager nginxingress openfaas cloud-minio
 
-kubectl delete certificates --all  -n openfaas
+kubectl delete certificates --all -n openfaas
+
 kubectl delete ns openfaas openfaas-fn
+kubectl delete ns cert-manager
 
 kubectl delete crd sealedsecrets.bitnami.com
 kubectl delete \
     -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
-
 kubectl delete deploy/sealed-secrets-controller -n kube-system
 kubectl delete deploy/tiller-deploy -n kube-system
 kubectl delete sa/tiller -n kube-system

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -3,9 +3,9 @@
 helm delete --purge cert-manager nginxingress openfaas cloud-minio
 
 kubectl delete certificates --all -n openfaas
+kubectl delete clusterissuer letsencrypt-prod letsencrypt-staging
 
-kubectl delete ns openfaas openfaas-fn
-kubectl delete ns cert-manager
+kubectl delete ns openfaas openfaas-fn cert-manager
 
 kubectl delete crd sealedsecrets.bitnami.com
 kubectl delete \

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -5,7 +5,8 @@ helm delete --purge cert-manager nginxingress openfaas cloud-minio
 kubectl delete certificates --all -n openfaas
 kubectl delete clusterissuer letsencrypt-prod letsencrypt-staging
 
-kubectl delete ns openfaas openfaas-fn cert-manager
+kubectl delete ns openfaas openfaas-fn 
+kubectl delete ns  cert-manager
 
 kubectl delete crd sealedsecrets.bitnami.com
 kubectl delete \

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 
 helm delete --purge cert-manager nginxingress openfaas cloud-minio
+
+kubectl delete certificates --all  -n openfaas
 kubectl delete ns openfaas openfaas-fn
+
 kubectl delete crd sealedsecrets.bitnami.com
+kubectl delete \
+    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
+
 kubectl delete deploy/sealed-secrets-controller -n kube-system
 kubectl delete deploy/tiller-deploy -n kube-system
 kubectl delete sa/tiller -n kube-system
 kubectl delete clusterrolebinding/tiller -n kube-system
-kubectl delete certificates --all  -n openfaas
+
+kubectl delete secret/clouddns-service-account -n kube-system
 
 rm -rf ./tmp

--- a/templates/k8s/tls/issuer-prod.yml
+++ b/templates/k8s/tls/issuer-prod.yml
@@ -25,4 +25,8 @@ spec:
           secretAccessKeySecretRef:
             name: "{{.DNSService}}-credentials-secret"
             key: secret-access-key
+          {{else if eq .DNSService "digitalocean" }}
+            tokenSecretRef:
+              name: digitalocean-dns
+              key: "{{.DigitalOceanAccessToken}}"
           {{ end }}

--- a/templates/k8s/tls/issuer-prod.yml
+++ b/templates/k8s/tls/issuer-prod.yml
@@ -28,5 +28,5 @@ spec:
           {{else if eq .DNSService "digitalocean" }}
             tokenSecretRef:
               name: digitalocean-dns
-              key: "{{.DigitalOceanAccessToken}}"
+              key: access-token
           {{ end }}

--- a/templates/k8s/tls/issuer-staging.yml
+++ b/templates/k8s/tls/issuer-staging.yml
@@ -25,4 +25,8 @@ spec:
           secretAccessKeySecretRef:
             name: "{{.DNSService}}-credentials-secret"
             key: secret-access-key
+          {{else if eq .DNSService "digitalocean" }}
+            tokenSecretRef:
+              name: digitalocean-dns
+              key: "{{.DigitalOceanAccessToken}}"
           {{ end }}

--- a/templates/k8s/tls/issuer-staging.yml
+++ b/templates/k8s/tls/issuer-staging.yml
@@ -28,5 +28,5 @@ spec:
           {{else if eq .DNSService "digitalocean" }}
             tokenSecretRef:
               name: digitalocean-dns
-              key: "{{.DigitalOceanAccessToken}}"
+              key: access-token
           {{ end }}


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

## Description

Add the ability to use DO for TLS / LE provisioning and bumps up cert-manager to 0.6.0

https://cert-manager.readthedocs.io/en/latest/reference/issuers/acme/dns01/digitalocean.html

https://github.com/helm/charts/tree/master/stable/cert-manager/templates

Configure as below:

```
  ### DigitalOcean
  dns_service: digitalocean
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with DigitalOcean Kubernetes with my domain assigned to DO's DNS service and DNS01 challenge.

Provisioned with staging, checked invalid CA, then followed updated steps for moving to a production workflow and got re-issued certs.

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
