### PR TITLE
Add secrets filter

### DIFF
--- a/example.init.yaml
+++ b/example.init.yaml
@@ -1,13 +1,27 @@
+features:
+  - "basic-auth"
+  - "scm-github"
+  - "jwt"
+  - "s3"
+  - "internal-trust"
+  - "auth"
+  - "registry"
+  - "do_dns01"
+
 orchestration: kubernetes
 secrets:
   ### Generated secrets (do not edit)
   - name: s3-secret-key
-    namespace: "openfaas-fn"
     literals:
       - name: s3-secret-key
+    filters:
+      - "s3"
+    namespace: "openfaas-fn"
   - name: s3-access-key
     literals:
       - name: s3-access-key
+    filters:
+      - "s3"
     namespace:  "openfaas-fn"
   - name: basic-auth
     literals:
@@ -15,23 +29,31 @@ secrets:
         value: admin
       - name: basic-auth-password
         value: ""
+    filters:
+      - "basic-auth"
     namespace:  "openfaas"
   - name: "payload-secret"
     literals:
       - name: payload-secret
         value: ""
+    filters:
+      - "internal-trust"
     namespace: "openfaas"
   - name: "jwt-private-key"
     files:
       - name: "key"
         value_from: "./tmp/key"
         value_command: "openssl ecparam -genkey -name prime256v1 -noout -out ./tmp/key"
+    filters:
+      - "jwt"
     namespace: "openfaas"
   - name: "jwt-public-key"
     files:
       - name: "key.pub"
         value_from: "./tmp/key.pub"
         value_command: "openssl ec -in ./tmp/key -pubout -out ./tmp/key.pub"
+    filters:
+      - "jwt"
     namespace: "openfaas"
 
   ### User-input
@@ -44,18 +66,24 @@ secrets:
     literals:
       - name: "github-webhook-secret"
         value: "secret"
+    filters:
+      - "scm-github"
     namespace: "openfaas-fn"
   # Download from GitHub App on GitHub UI
   - name: "private-key"
     files:
       - name: "private-key"
         value_from: "~/Downloads/private-key.pem"
+    filters:
+      - "scm-github"
     namespace: "openfaas-fn"
   # Populate your OAuth client_secret
   - name: "of-client-secret"
     literals:
       - name: of-client-secret
         value: "79163355e553b477957d977b0b8addd3c42ff52d"
+    filters:
+      - "auth"
     namespace: "openfaas"
   # DNS Service Account secret
 
@@ -64,6 +92,8 @@ secrets:
     files:
       - name: "access-token"
         value_from: "~/Downloads/do-access-token"
+    filters:
+      - "do_dns01"
     namespace: "cert-manager"
 
   ## Use Google Cloud DNS	
@@ -84,6 +114,8 @@ secrets:
     files:
       - name: "config.json"
         value_from: "~/.docker/config.json"
+    filters:
+      - "registry"
     namespace: "openfaas"
 
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Plan struct {
+	Features      []string                 `yaml:"features"`
 	Orchestration string                   `yaml:"orchestration"`
 	Secrets       []KeyValueNamespaceTuple `yaml:"secrets"`
 	RootDomain    string                   `yaml:"root_domain"`
@@ -48,6 +49,7 @@ type KeyValueNamespaceTuple struct {
 	Literals  []KeyValueTuple `yaml:"literals"`
 	Namespace string          `yaml:"namespace"`
 	Files     []FileSecret    `yaml:"files"`
+	Filters   []string        `yaml:"filters"`
 }
 
 type Github struct {


### PR DESCRIPTION
Adding filter which filters which secrets
we create, since ATM we create all secrets
when we dont need big part of them

Signed-off-by: Martin Dekov <mdekov@vmware.com>

## Description

ATM there is no way to filter the creation of secrets aka. we create all secrets even though we don't really need big part of them.

Closes #59 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in isolation the following way:

1. Left the code which is responsible for creating secrets, commented out the rest
2. Defined feature like so:
```
features:
  - "auth"
```
3. Map the feature so existing secret:
```
...
secrets:
  ### Generated secrets (do not edit)
  - name: s3-secret-key
    literals:
      - name: s3-secret-key
    filters:
      - "auth"
...
```
4. Ran `./ofc-bootstrap` to see only 1 secret created `s3-secret-key`

## Additional work

When PR about [GitLab](https://github.com/openfaas-incubator/ofc-bootstrap/pull/46) and [Swarm](https://github.com/openfaas-incubator/ofc-bootstrap/pull/69/files) are merged features can be added to filter the secrets based on orchestration and SCM

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md < ---- `TO DO`
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

