### PR TITLE
Fix typo in script

### DIFF
--- a/hack/ci.sh
+++ b/hack/ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ./scripts/reset-kind.sh
 export KUBECONFIG="$(kind get kubeconfig-path --name="1")"
-go buiild
+go build
 
 # Fake the secrets from init.yaml
 


### PR DESCRIPTION
Fixing typo in script which makes Travis
CI fail

Signed-off-by: mdekov <mdekov@vmware.com>

## Description

Typo in the `ci.sh` which prevented the passing of a build

![image](https://user-images.githubusercontent.com/34942004/52860795-2aa71280-3139-11e9-9a58-f25fb57fb8f1.png)

and 

![image](https://user-images.githubusercontent.com/34942004/52861007-cb95cd80-3139-11e9-9b6b-552441c1f146.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Local build ran `./ci.sh`

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

