### PR TITLE
Add node10-express template

### DIFF
--- a/templates/gateway_config.yml
+++ b/templates/gateway_config.yml
@@ -8,7 +8,7 @@ environment:
   gateway_pretty_url: {{.Scheme}}://user.{{.RootDomain}}/function
   # Add your custom templates by adding a coma separated URL, i.e. extend the current value with:
   # ", https://github.com/custom/template.git, https://github.com/custom/template2.git"
-  custom_templates: "https://github.com/openfaas-incubator/node8-express-template.git, https://github.com/openfaas-incubator/golang-http-template.git"
+  custom_templates: "https://github.com/openfaas-incubator/node8-express-template.git, https://github.com/openfaas-incubator/golang-http-template.git, https://github.com/openfaas-incubator/node10-express-template.git"
 
 # Security
   customers_url: "{{.CustomersURL}}"


### PR DESCRIPTION
Signed-off-by: doowb <brian.woodward@gmail.com>

## Description

- Add node10-express-template repo to the custom templates property in the gateway_config.yaml template.

## Checklist:

I have:

- [X] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests

