### PR TITLE
Add link to docs for GitHub App

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ First run `cp example.init.yaml init.yaml` to get your own example `init.yaml` f
 * Open the Docker for Mac/Windows settings and uncheck "store my password securely" / "in a keychain"
 * Run `docker login` to populate `~/.docker/config.json` - this will be used to configure your Docker registry or Docker Hub account for functions.
 * Create a GitHub App and download the private key file
+  * Read the docs for how to [configure your GitHub App](https://docs.openfaas.com/openfaas-cloud/self-hosted/github/)
 * If your username is not part of the default CUSTOMERS file for OpenFaaS then you should point to your own plaintext file - make sure you use the GitHub Raw CDN URL for this
 * Update `init.yaml` where you see the `### User-input` section including your GitHub App's ID and the path to its private key
 


### PR DESCRIPTION
## Description
The docs page describes in detail the steps needed to properly
configure the GitHub App to work with OpenFaaS Cloud

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist:

I have:

- [X] checked my changes follow the style of the existing code / OpenFaaS repos
- [X] updated the documentation and/or roadmap in README.md
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests - **N/A**

