### PR TITLE
Fix ingress when TLS is disabled

### DIFF
--- a/templates/k8s/ingress-wildcard.yml
+++ b/templates/k8s/ingress-wildcard.yml
@@ -5,11 +5,13 @@ metadata:
   name: openfaas-ingress
   namespace: openfaas
   annotations:
+    {{ if .TLS }}
     certmanager.k8s.io/acme-challenge-type: dns01
     certmanager.k8s.io/acme-dns01-provider: {{.DNSService}}
-    kubernetes.io/tls-acme: "true"
-    kubernetes.io/ingress.class: "nginx"
     certmanager.k8s.io/cluster-issuer: letsencrypt-{{.IssuerType}}
+    kubernetes.io/tls-acme: "true"
+    {{ end }}
+    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/limit-connections: "20"
     nginx.ingress.kubernetes.io/limit-rpm: "600"
   labels:

--- a/templates/k8s/ingress.yml
+++ b/templates/k8s/ingress.yml
@@ -5,11 +5,13 @@ metadata:
   name: openfaas-auth-ingress
   namespace: openfaas
   annotations:
+    {{ if .TLS }}
     certmanager.k8s.io/acme-challenge-type: dns01
     certmanager.k8s.io/acme-dns01-provider: {{.DNSService}}
-    kubernetes.io/tls-acme: "true"
-    kubernetes.io/ingress.class: "nginx"
     certmanager.k8s.io/cluster-issuer: letsencrypt-{{.IssuerType}}
+    kubernetes.io/tls-acme: "true"
+    {{ end }}
+    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/limit-connections: "20"
     nginx.ingress.kubernetes.io/limit-rpm: "600"
   labels:


### PR DESCRIPTION
Certmanager annotations were previously added to Ingress even when TLS was false. With this change they are generated only when it is enabled

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running `off-bootstrap`, checking  generated templates and cluster resources, accessing the dashboard

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md N/A
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests N/A
