### PR TITLE
Create pull secrets for kubernetes

### DIFF
--- a/example.init.yaml
+++ b/example.init.yaml
@@ -85,6 +85,12 @@ secrets:
       - name: "config.json"
         value_from: "~/.docker/config.json"
     namespace: "openfaas"
+  - name: "registry-secret"
+    files:
+      - name: ".dockerconfigjson"
+        value_from: "~/.docker/config.json"
+    namespace: "openfaas-fn"
+    type: "kubernetes.io/dockerconfigjson"
 
 
 ### Docker registry	

--- a/main.go
+++ b/main.go
@@ -174,6 +174,11 @@ func process(plan types.Plan) error {
 
 		createSecrets(plan)
 
+		saErr := patchFnServiceaccount()
+		if saErr != nil {
+			log.Println(saErr)
+		}
+
 		minioErr := installMinio()
 		if minioErr != nil {
 			log.Println(minioErr)
@@ -399,6 +404,26 @@ func installMinio() error {
 
 	task := execute.ExecTask{
 		Command: "scripts/install-minio.sh",
+		Shell:   true,
+	}
+
+	res, err := task.Execute()
+
+	if err != nil {
+		return err
+	}
+
+	log.Println(res.Stdout)
+	log.Println(res.Stderr)
+
+	return nil
+}
+
+func patchFnServiceaccount() error {
+	log.Println("Patching openfaas-fn serviceaccount for pull secrets")
+
+	task := execute.ExecTask{
+		Command: "scripts/patch-fn-serviceaccount.sh",
 		Shell:   true,
 	}
 

--- a/pkg/types/secrets.go
+++ b/pkg/types/secrets.go
@@ -22,6 +22,10 @@ func CreateDockerSecret(kvn KeyValueNamespaceTuple) string {
 func CreateK8sSecret(kvn KeyValueNamespaceTuple) string {
 	secretCmd := fmt.Sprintf("kubectl create secret generic -n %s %s", kvn.Namespace, kvn.Name)
 
+	if len(kvn.Type) != 0 {
+		secretCmd = fmt.Sprintf("%s --type=%s", secretCmd, kvn.Type)
+	}
+
 	for _, key := range kvn.Literals {
 		secretValue := key.Value
 		if len(secretValue) == 0 {
@@ -34,6 +38,7 @@ func CreateK8sSecret(kvn KeyValueNamespaceTuple) string {
 		}
 
 		secretCmd = fmt.Sprintf(`%s --from-literal=%s=%s`, secretCmd, key.Name, secretValue)
+
 	}
 
 	for _, file := range kvn.Files {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -48,6 +48,7 @@ type KeyValueNamespaceTuple struct {
 	Literals  []KeyValueTuple `yaml:"literals"`
 	Namespace string          `yaml:"namespace"`
 	Files     []FileSecret    `yaml:"files"`
+	Type      string          `yaml:"type"`
 }
 
 type Github struct {

--- a/scripts/patch-fn-serviceaccount.sh
+++ b/scripts/patch-fn-serviceaccount.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kubectl patch serviceaccount default -p '{"secrets": [{"name": "registry-secret"}]}' -n openfaas-fn

--- a/scripts/patch-fn-serviceaccount.sh
+++ b/scripts/patch-fn-serviceaccount.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kubectl patch serviceaccount default -p '{"secrets": [{"name": "registry-secret"}]}' -n openfaas-fn
+kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "registry-secret"}]}' -n openfaas-fn


### PR DESCRIPTION
Create secrets to pull function images from private docker registry
for kubernetes.

Fixes: #80

Signed-off-by: Vivek Singh <viveks@akamai.com>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested this on my OpenFaaS cluster with a private repository on docker hub for my function.

http://system.vs.team-serverless.xyz/dashboard/viveksyngh/

Function Repo: 
https://github.com/viveksyngh/private-func

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

