### PR TITLE
Renamed faasnetesd to faasnetes

### DIFF
--- a/scripts/install-openfaas.sh
+++ b/scripts/install-openfaas.sh
@@ -13,7 +13,7 @@ helm upgrade openfaas --install openfaas/openfaas \
     --set gateway.writeTimeout=15m \
     --set gateway.upstreamTimeout=14m55s \
     --set queueWorker.ackWait=15m \
-    --set faasnetesd.readTimeout=5m \
-    --set faasnetesd.writeTimeout=5m \
+    --set faasnetes.readTimeout=5m \
+    --set faasnetes.writeTimeout=5m \
     --set gateway.replicas=2 \
     --set queueWorker.replicas=2


### PR DESCRIPTION
Signed-off-by: Rishabh Gupta <r.g.gupta@outlook.com>

## Description
`faasnetesd` was renamed to `faasnetes` in helm chart values, this PR renames it in ofc-bootstrap. Issue arises with the `read_timeout` and `write_timeout` settings for faas-netes container in `gateway` pods.

## How Has This Been Tested?
Tested on a kind cluster.

## Checklist:

I have:

- [ ] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests

