### PR TITLE
[Testing] Use `kubectl rollout status` for readiness check

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,6 +254,8 @@ func process(plan types.Plan) error {
 			return cloneErr
 		}
 
+		openfaasGatewayReady()
+
 		deployErr := deployCloudComponents(plan)
 		if (deployErr) != nil {
 			return deployErr
@@ -261,6 +263,16 @@ func process(plan types.Plan) error {
 	}
 
 	return nil
+}
+
+func openfaasGatewayReady() {
+	task := execute.ExecTask{
+		Command: "kubectl rollout status deploy/gateway -n openfaas",
+		Shell:   true,
+	}
+
+	res, err := task.Execute()
+	fmt.Println("cert-manager", res.ExitCode, res.Stdout, res.Stderr, err)
 }
 
 func helmRepoUpdate() error {

--- a/main.go
+++ b/main.go
@@ -254,8 +254,6 @@ func process(plan types.Plan) error {
 			return cloneErr
 		}
 
-		openfaasGatewayReady()
-
 		deployErr := deployCloudComponents(plan)
 		if (deployErr) != nil {
 			return deployErr
@@ -263,16 +261,6 @@ func process(plan types.Plan) error {
 	}
 
 	return nil
-}
-
-func openfaasGatewayReady() {
-	task := execute.ExecTask{
-		Command: "scripts/get-openfaas-gateway.sh",
-		Shell:   true,
-	}
-
-	res, err := task.Execute()
-	fmt.Println("cert-manager", res.ExitCode, res.Stdout, res.Stderr, err)
 }
 
 func helmRepoUpdate() error {

--- a/main.go
+++ b/main.go
@@ -267,7 +267,7 @@ func process(plan types.Plan) error {
 
 func openfaasGatewayReady() {
 	task := execute.ExecTask{
-		Command: "/scripts/get-openfaas-gateway.sh",
+		Command: "scripts/get-openfaas-gateway.sh",
 		Shell:   true,
 	}
 

--- a/main.go
+++ b/main.go
@@ -267,7 +267,7 @@ func process(plan types.Plan) error {
 
 func openfaasGatewayReady() {
 	task := execute.ExecTask{
-		Command: "kubectl rollout status deploy/gateway -n openfaas",
+		Command: "/scripts/get-openfaas-gateway.sh",
 		Shell:   true,
 	}
 

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -39,18 +39,9 @@ faas-cli template pull
 kubectl port-forward svc/gateway -n openfaas 31111:8080 &
 sleep 2
 
-# for i in {1..60};
-# do
-#     echo "Checking if OpenFaaS GW is up."
+echo "Checking if OpenFaaS GW is up."
 
-#     curl -if 127.0.0.1:31111
-#     if [ $? == 0 ];
-#     then
-#         break
-#     fi
-
-#     sleep 1
-# done
+kubectl rollout status deploy/gateway -n openfaas
 
 
 export OPENFAAS_URL=http://127.0.0.1:31111

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -43,6 +43,7 @@ echo "Checking if OpenFaaS GW is up."
 
 kubectl rollout status deploy/gateway -n openfaas --timeout=10m
 
+sleep 2
 
 export OPENFAAS_URL=http://127.0.0.1:31111
 echo -n $ADMIN_PASSWORD | faas-cli login --username admin --password-stdin

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -39,18 +39,18 @@ faas-cli template pull
 kubectl port-forward svc/gateway -n openfaas 31111:8080 &
 sleep 2
 
-for i in {1..60};
-do
-    echo "Checking if OpenFaaS GW is up."
+# for i in {1..60};
+# do
+#     echo "Checking if OpenFaaS GW is up."
 
-    curl -if 127.0.0.1:31111
-    if [ $? == 0 ];
-    then
-        break
-    fi
+#     curl -if 127.0.0.1:31111
+#     if [ $? == 0 ];
+#     then
+#         break
+#     fi
 
-    sleep 1
-done
+#     sleep 1
+# done
 
 
 export OPENFAAS_URL=http://127.0.0.1:31111

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -41,7 +41,7 @@ sleep 2
 
 echo "Checking if OpenFaaS GW is up."
 
-kubectl rollout status deploy/gateway -n openfaas
+kubectl rollout status deploy/gateway -n openfaas --timeout=10m
 
 
 export OPENFAAS_URL=http://127.0.0.1:31111

--- a/scripts/get-cert-manager.sh
+++ b/scripts/get-cert-manager.sh
@@ -3,3 +3,5 @@
 # cert-manager is ready for CRD objects when this condition is "True"
 kubectl rollout status cert/cert-manager-webhook-webhook-tls -n  cert-manager --timeout=10m
 kubectl rollout status deploy/cert-manager-webhook -n cert-manager --timeout=10m
+
+sleep 2

--- a/scripts/get-cert-manager.sh
+++ b/scripts/get-cert-manager.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
 # cert-manager is ready for CRD objects when this condition is "True"
-CERT_READY=$(kubectl get cert/cert-manager-webhook-webhook-tls -n  cert-manager -o jsonpath="{.status.conditions[0].status}")
-WEBHOOK_READY=$(kubectl get deploy/cert-manager-webhook -n cert-manager -o jsonpath="{.status.conditions[0].status}")
-
-if [ "$CERT_READY" = "True" ]
-then
-    if [ "$WEBHOOK_READY" = "True" ]
-    then
-        echo -n True
-    fi
-fi
+kubectl rollout status cert/cert-manager-webhook-webhook-tls -n  cert-manager
+kubectl rollout status deploy/cert-manager-webhook -n cert-manager

--- a/scripts/get-cert-manager.sh
+++ b/scripts/get-cert-manager.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # cert-manager is ready for CRD objects when this condition is "True"
-kubectl rollout status cert/cert-manager-webhook-webhook-tls -n  cert-manager
-kubectl rollout status deploy/cert-manager-webhook -n cert-manager
+kubectl rollout status cert/cert-manager-webhook-webhook-tls -n  cert-manager --timeout=10m
+kubectl rollout status deploy/cert-manager-webhook -n cert-manager --timeout=10m

--- a/scripts/get-openfaas-gateway.sh
+++ b/scripts/get-openfaas-gateway.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kubectl rollout status deploy/gateway -n openfaas

--- a/scripts/get-openfaas-gateway.sh
+++ b/scripts/get-openfaas-gateway.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-kubectl rollout status deploy/gateway -n openfaas

--- a/scripts/get-sealedsecretscontroller.sh
+++ b/scripts/get-sealedsecretscontroller.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kubectl get deploy/ofc-sealedsecrets-sealed-secrets -n kube-system --output="jsonpath={.status.availableReplicas}"
+kubectl rollout status deploy/ofc-sealedsecrets-sealed-secrets -n kube-system

--- a/scripts/get-sealedsecretscontroller.sh
+++ b/scripts/get-sealedsecretscontroller.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kubectl rollout status deploy/ofc-sealedsecrets-sealed-secrets -n kube-system
+kubectl rollout status deploy/ofc-sealedsecrets-sealed-secrets -n kube-system --timeout=10m

--- a/scripts/get-tiller.sh
+++ b/scripts/get-tiller.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kubectl rollout status deployment/tiller-deploy -n kube-system
+kubectl rollout status deployment/tiller-deploy -n kube-system --timeout=10m

--- a/scripts/get-tiller.sh
+++ b/scripts/get-tiller.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kubectl get deploy/tiller-deploy -n kube-system --output="jsonpath={.status.availableReplicas}"
+kubectl rollout status deployment/tiller-deploy -n kube-system


### PR DESCRIPTION
## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on kubernetes without TLS enabled and deployed here. 

https://system.vs.team-serverless.xyz/dashboard/viveksyngh/

<details>
<summary>Output</summary>

```
root@swarm042:~/go-projects/src/github.com/openfaas-incubator/ofc-bootstrap# ./ofc-bootstrap -yaml=init.local.yaml
2019/04/06 22:17:35 Validating tools available in PATH
exec:  kubectl version --client
res: Client Version: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.3", GitCommit:"721bfa751924da8d1680787490c54b9179b1fed0", GitTreeState:"clean", BuildDate:"2019-02-01T20:08:12Z", GoVersion:"go1.11.5", Compiler:"gc", Platform:"linux/amd64"}

exec:  openssl version
res: OpenSSL 1.0.2g  1 Mar 2016

exec:  helm version -c
res: Client: &version.Version{SemVer:"v2.12.3", GitCommit:"eecf22f77df5f65c823aacd2dbd30ae6c65f186e", GitTreeState:"clean"}

exec:  faas-cli version
res:   ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  a141dedf94ffeed84412365fd591bdc8999c5a1b
 version: 0.8.3

Plan loaded from: init.local.yaml
Orchestration: Kubernetes
2019/04/06 22:17:36 Creating namespaces
exec:  scripts/create-namespaces.sh
res: namespace/openfaas created
namespace/openfaas-fn created
namespace/cert-manager created
namespace/cert-manager labeled
NAME           STATUS   AGE
cert-manager   Active   0s
default        Active   57d
kube-public    Active   57d
kube-system    Active   57d
openfaas       Active   0s
openfaas-fn    Active   0s

2019/04/06 22:17:36 0 namespace/openfaas created
namespace/openfaas-fn created
namespace/cert-manager created
namespace/cert-manager labeled
NAME           STATUS   AGE
cert-manager   Active   0s
default        Active   57d
kube-public    Active   57d
kube-system    Active   57d
openfaas       Active   0s
openfaas-fn    Active   0s

Building Ingress
2019/04/06 22:17:36 Creating Tiller
exec:  scripts/create-tiller-sa.sh
res: serviceaccount/tiller created
clusterrolebinding.rbac.authorization.k8s.io/tiller created

2019/04/06 22:17:37 serviceaccount/tiller created
clusterrolebinding.rbac.authorization.k8s.io/tiller created

2019/04/06 22:17:37
exec:  scripts/create-tiller.sh
res: $HELM_HOME has been configured at /root/.helm.

Tiller (the Helm server-side component) has been upgraded to the current version.
Happy Helming!

2019/04/06 22:17:37 $HELM_HOME has been configured at /root/.helm.

Tiller (the Helm server-side component) has been upgraded to the current version.
Happy Helming!

2019/04/06 22:17:37
2019/04/06 22:17:37 Is tiller rolled out?
exec:  ./scripts/get-tiller.sh
res: Waiting for deployment "tiller-deploy" rollout to finish: 0 of 1 updated replicas are available...
deployment "tiller-deploy" successfully rolled out

tiller 0 Waiting for deployment "tiller-deploy" rollout to finish: 0 of 1 updated replicas are available...
deployment "tiller-deploy" successfully rolled out
  <nil>
2019/04/06 22:17:45 Updating helm repos
exec:  helm repo update
res: Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈

2019/04/06 22:17:46 Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈

2019/04/06 22:17:46
2019/04/06 22:17:46 Creating Ingress Controller
exec:  scripts/install-nginx.sh
res: helm install stable/nginx-ingress --name nginxingress --set rbac.create=true,controller.hostNetwork=true,controller.daemonset.useHostPort=true,dnsPolicy=ClusterFirstWithHostNet,controller.kind=DaemonSet
NAME:   nginxingress
LAST DEPLOYED: Sat Apr  6 22:17:48 2019
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/ServiceAccount
NAME                        SECRETS  AGE
nginxingress-nginx-ingress  1        0s

==> v1beta1/RoleBinding
NAME                        AGE
nginxingress-nginx-ingress  0s

==> v1/Service
NAME                                        TYPE          CLUSTER-IP     EXTERNAL-IP  PORT(S)                     AGE
nginxingress-nginx-ingress-controller       LoadBalancer  10.102.166.67  <pending>    80:30619/TCP,443:30075/TCP  0s
nginxingress-nginx-ingress-default-backend  ClusterIP     10.106.20.96   <none>       80/TCP                      0s

==> v1beta1/DaemonSet
NAME                                   DESIRED  CURRENT  READY  UP-TO-DATE  AVAILABLE  NODE SELECTOR  AGE
nginxingress-nginx-ingress-controller  1        1        0      1           0          <none>         0s

==> v1/ConfigMap
NAME                                   DATA  AGE
nginxingress-nginx-ingress-controller  1     0s

==> v1beta1/ClusterRole
NAME                        AGE
nginxingress-nginx-ingress  0s

==> v1beta1/ClusterRoleBinding
NAME                        AGE
nginxingress-nginx-ingress  0s

==> v1beta1/Role
NAME                        AGE
nginxingress-nginx-ingress  0s

==> v1beta1/Deployment
NAME                                        DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
nginxingress-nginx-ingress-default-backend  1        1        1           0          0s

==> v1/Pod(related)
NAME                                                         READY  STATUS             RESTARTS  AGE
nginxingress-nginx-ingress-controller-zrv47                  0/1    ContainerCreating  0         0s
nginxingress-nginx-ingress-default-backend-678767676f-z9f4m  0/1    ContainerCreating  0         0s


NOTES:
The nginx-ingress controller has been installed.
It may take a few minutes for the LoadBalancer IP to be available.
You can watch the status by running 'kubectl --namespace default get services -o wide -w nginxingress-nginx-ingress-controller'

An example Ingress that makes use of the controller:

  apiVersion: extensions/v1beta1
  kind: Ingress
  metadata:
    annotations:
      kubernetes.io/ingress.class: nginx
    name: example
    namespace: foo
  spec:
    rules:
      - host: www.example.com
        http:
          paths:
            - backend:
                serviceName: exampleService
                servicePort: 80
              path: /
    # This section is only required if TLS is to be enabled for the Ingress
    tls:
        - hosts:
            - www.example.com
          secretName: example-tls

If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:

  apiVersion: v1
  kind: Secret
  metadata:
    name: example-tls
    namespace: foo
  data:
    tls.crt: <base64 encoded cert>
    tls.key: <base64 encoded key>
  type: kubernetes.io/tls


2019/04/06 22:17:48 0 helm install stable/nginx-ingress --name nginxingress --set rbac.create=true,controller.hostNetwork=true,controller.daemonset.useHostPort=true,dnsPolicy=ClusterFirstWithHostNet,controller.kind=DaemonSet
NAME:   nginxingress
LAST DEPLOYED: Sat Apr  6 22:17:48 2019
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/ServiceAccount
NAME                        SECRETS  AGE
nginxingress-nginx-ingress  1        0s

==> v1beta1/RoleBinding
NAME                        AGE
nginxingress-nginx-ingress  0s

==> v1/Service
NAME                                        TYPE          CLUSTER-IP     EXTERNAL-IP  PORT(S)                     AGE
nginxingress-nginx-ingress-controller       LoadBalancer  10.102.166.67  <pending>    80:30619/TCP,443:30075/TCP  0s
nginxingress-nginx-ingress-default-backend  ClusterIP     10.106.20.96   <none>       80/TCP                      0s

==> v1beta1/DaemonSet
NAME                                   DESIRED  CURRENT  READY  UP-TO-DATE  AVAILABLE  NODE SELECTOR  AGE
nginxingress-nginx-ingress-controller  1        1        0      1           0          <none>         0s

==> v1/ConfigMap
NAME                                   DATA  AGE
nginxingress-nginx-ingress-controller  1     0s

==> v1beta1/ClusterRole
NAME                        AGE
nginxingress-nginx-ingress  0s

==> v1beta1/ClusterRoleBinding
NAME                        AGE
nginxingress-nginx-ingress  0s

==> v1beta1/Role
NAME                        AGE
nginxingress-nginx-ingress  0s

==> v1beta1/Deployment
NAME                                        DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
nginxingress-nginx-ingress-default-backend  1        1        1           0          0s

==> v1/Pod(related)
NAME                                                         READY  STATUS             RESTARTS  AGE
nginxingress-nginx-ingress-controller-zrv47                  0/1    ContainerCreating  0         0s
nginxingress-nginx-ingress-default-backend-678767676f-z9f4m  0/1    ContainerCreating  0         0s


NOTES:
The nginx-ingress controller has been installed.
It may take a few minutes for the LoadBalancer IP to be available.
You can watch the status by running 'kubectl --namespace default get services -o wide -w nginxingress-nginx-ingress-controller'

An example Ingress that makes use of the controller:

  apiVersion: extensions/v1beta1
  kind: Ingress
  metadata:
    annotations:
      kubernetes.io/ingress.class: nginx
    name: example
    namespace: foo
  spec:
    rules:
      - host: www.example.com
        http:
          paths:
            - backend:
                serviceName: exampleService
                servicePort: 80
              path: /
    # This section is only required if TLS is to be enabled for the Ingress
    tls:
        - hosts:
            - www.example.com
          secretName: example-tls

If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:

  apiVersion: v1
  kind: Secret
  metadata:
    name: example-tls
    namespace: foo
  data:
    tls.crt: <base64 encoded cert>
    tls.key: <base64 encoded key>
  type: kubernetes.io/tls


Creating secret: s3-secret-key
exec:  scripts/generate-sha.sh
res: 0af67e625eb1db4a737b5222e37726e69f19dcc2
exec:  kubectl create secret generic -n openfaas-fn s3-secret-key --from-literal=s3-secret-key=2e18dee97d1655f964c4198239752e01800ab874e9135c52a80dfd83079aa0fb
res: secret/s3-secret-key created

{secret/s3-secret-key created
  0}
Creating secret: s3-access-key
exec:  scripts/generate-sha.sh
res: 9cf31212e5c1e4568fa25bf3f58c39fa377fcf9f
exec:  kubectl create secret generic -n openfaas-fn s3-access-key --from-literal=s3-access-key=56abf7f727e983ec956b4db1418b131b830a9a2f7487965b247c5b3fd003974f
res: secret/s3-access-key created

{secret/s3-access-key created
  0}
Creating secret: basic-auth
exec:  kubectl create secret generic -n openfaas basic-auth --from-literal=basic-auth-user=admin --from-literal=basic-auth-password=admin
res: secret/basic-auth created

{secret/basic-auth created
  0}
Creating secret: payload-secret
exec:  scripts/generate-sha.sh
res: 23e720275d1d1f0d6175dcfe2070c9fe98a6e7fb
exec:  kubectl create secret generic -n openfaas payload-secret --from-literal=payload-secret=85786c12447ac74251c3481e594ac8207e4fd44f88adce70d63a524c68ea923a
res: secret/payload-secret created

{secret/payload-secret created
  0}
Creating secret: jwt-private-key
exec:  openssl ecparam -genkey -name prime256v1 -noout -out ./tmp/key
res:
exec:  kubectl create secret generic -n openfaas jwt-private-key --from-file=key=./tmp/key
res: secret/jwt-private-key created

{secret/jwt-private-key created
  0}
Creating secret: jwt-public-key
exec:  openssl ec -in ./tmp/key -pubout -out ./tmp/key.pub
res:
exec:  kubectl create secret generic -n openfaas jwt-public-key --from-file=key.pub=./tmp/key.pub
res: secret/jwt-public-key created

{secret/jwt-public-key created
  0}
Creating secret: github-webhook-secret
exec:  kubectl create secret generic -n openfaas-fn github-webhook-secret --from-literal=github-webhook-secret=89f0f38caf8527628d3f8633dc9fa3234d51ea53
res: secret/github-webhook-secret created

{secret/github-webhook-secret created
  0}
Creating secret: private-key
exec:  kubectl create secret generic -n openfaas-fn private-key --from-file=private-key=/tmp/openfaas-cloud.2018-04-28.private-key.pem
res: secret/private-key created

{secret/private-key created
  0}
Creating secret: of-client-secret
exec:  kubectl create secret generic -n openfaas of-client-secret --from-literal=of-client-secret=ac7b2f142f5b037ee48b59da5968178b25484335
res: secret/of-client-secret created

{secret/of-client-secret created
  0}
Creating secret: digitalocean-dns
exec:  kubectl create secret generic -n cert-manager digitalocean-dns --from-file=access-token=/root/access-token
res: secret/digitalocean-dns created

{secret/digitalocean-dns created
  0}
Creating secret: registry-secret
exec:  kubectl create secret generic -n openfaas registry-secret --from-file=config.json=/root/.docker/config.json
res: secret/registry-secret created

{secret/registry-secret created
  0}
Creating secret: registry-pull-secret
exec:  kubectl create secret generic -n openfaas-fn registry-pull-secret --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=/root/.docker/config.json
res: secret/registry-pull-secret created

{secret/registry-pull-secret created
  0}
2019/04/06 22:17:50 Patching openfaas-fn serviceaccount for pull secrets
exec:  scripts/patch-fn-serviceaccount.sh
res: serviceaccount/default patched

2019/04/06 22:17:51 serviceaccount/default patched

2019/04/06 22:17:51
2019/04/06 22:17:51 Creating Minio
exec:  scripts/install-minio.sh
res: NAME:   cloud-minio
LAST DEPLOYED: Sat Apr  6 22:17:52 2019
NAMESPACE: openfaas
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME         TYPE      CLUSTER-IP      EXTERNAL-IP  PORT(S)         AGE
cloud-minio  NodePort  10.103.164.212  <none>       9000:31311/TCP  1s

==> v1beta2/Deployment
NAME         DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
cloud-minio  1        1        1           0          1s

==> v1/Pod(related)
NAME                          READY  STATUS             RESTARTS  AGE
cloud-minio-786cb7b86b-c5n7p  0/1    ContainerCreating  0         1s

==> v1/Secret
NAME         TYPE    DATA  AGE
cloud-minio  Opaque  2     1s

==> v1/ConfigMap
NAME         DATA  AGE
cloud-minio  1     1s


NOTES:

Minio can be accessed via port 9000 on the following DNS name from within your cluster:
cloud-minio.openfaas.svc.cluster.local

To access Minio from localhost, run the below commands:

  1. export POD_NAME=$(kubectl get pods --namespace openfaas -l "release=cloud-minio" -o jsonpath="{.items[0].metadata.name}")

  2. kubectl port-forward $POD_NAME 9000 --namespace openfaas

Read more about port forwarding here: http://kubernetes.io/docs/user-guide/kubectl/kubectl_port-forward/

You can now access Minio server on http://localhost:9000. Follow the below steps to connect to Minio server with mc client:

  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide

  2. mc config host add cloud-minio-local http://localhost:9000 56abf7f727e983ec956b4db1418b131b830a9a2f7487965b247c5b3fd003974f 2e18dee97d1655f964c4198239752e01800ab874e9135c52a80dfd83079aa0fb S3v4

  3. mc ls cloud-minio-local

Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17




2019/04/06 22:17:53 NAME:   cloud-minio
LAST DEPLOYED: Sat Apr  6 22:17:52 2019
NAMESPACE: openfaas
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME         TYPE      CLUSTER-IP      EXTERNAL-IP  PORT(S)         AGE
cloud-minio  NodePort  10.103.164.212  <none>       9000:31311/TCP  1s

==> v1beta2/Deployment
NAME         DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
cloud-minio  1        1        1           0          1s

==> v1/Pod(related)
NAME                          READY  STATUS             RESTARTS  AGE
cloud-minio-786cb7b86b-c5n7p  0/1    ContainerCreating  0         1s

==> v1/Secret
NAME         TYPE    DATA  AGE
cloud-minio  Opaque  2     1s

==> v1/ConfigMap
NAME         DATA  AGE
cloud-minio  1     1s


NOTES:

Minio can be accessed via port 9000 on the following DNS name from within your cluster:
cloud-minio.openfaas.svc.cluster.local

To access Minio from localhost, run the below commands:

  1. export POD_NAME=$(kubectl get pods --namespace openfaas -l "release=cloud-minio" -o jsonpath="{.items[0].metadata.name}")

  2. kubectl port-forward $POD_NAME 9000 --namespace openfaas

Read more about port forwarding here: http://kubernetes.io/docs/user-guide/kubectl/kubectl_port-forward/

You can now access Minio server on http://localhost:9000. Follow the below steps to connect to Minio server with mc client:

  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide

  2. mc config host add cloud-minio-local http://localhost:9000 56abf7f727e983ec956b4db1418b131b830a9a2f7487965b247c5b3fd003974f 2e18dee97d1655f964c4198239752e01800ab874e9135c52a80dfd83079aa0fb S3v4

  3. mc ls cloud-minio-local

Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17




2019/04/06 22:17:53
2019/04/06 22:17:53 Creating Cert-Manager
exec:  scripts/install-cert-manager.sh
res: customresourcedefinition.apiextensions.k8s.io/certificates.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/issuers.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/clusterissuers.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/orders.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/challenges.certmanager.k8s.io created
NAME:   cert-manager
LAST DEPLOYED: Sat Apr  6 22:17:55 2019
NAMESPACE: cert-manager
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME                  TYPE       CLUSTER-IP      EXTERNAL-IP  PORT(S)  AGE
cert-manager-webhook  ClusterIP  10.101.238.134  <none>       443/TCP  2s

==> v1/ServiceAccount
NAME                          SECRETS  AGE
cert-manager-webhook-ca-sync  1        2s
cert-manager-webhook          1        2s
cert-manager                  1        2s

==> v1/Pod(related)
NAME                                   READY  STATUS             RESTARTS  AGE
cert-manager-webhook-67cfb86d56-c9dpp  0/1    ContainerCreating  0         2s
cert-manager-67884fcbfc-p9zgl          0/1    ContainerCreating  0         2s
cert-manager-webhook-ca-sync-n6rvm     0/1    ContainerCreating  0         2s

==> v1/ConfigMap
NAME                          DATA  AGE
cert-manager-webhook-ca-sync  1     2s

==> v1/Job
NAME                          COMPLETIONS  DURATION  AGE
cert-manager-webhook-ca-sync  0/1          2s        2s

==> v1beta1/APIService
NAME                                  AGE
v1beta1.admission.certmanager.k8s.io  2s

==> v1alpha1/Issuer
NAME                           AGE
cert-manager-webhook-ca        1s
cert-manager-webhook-selfsign  1s

==> v1beta1/ValidatingWebhookConfiguration
NAME                  AGE
cert-manager-webhook  1s

==> v1beta1/ClusterRole
NAME                          AGE
cert-manager-webhook-ca-sync  2s
cert-manager                  2s

==> v1/ClusterRole
NAME                                    AGE
cert-manager-webhook:webhook-requester  2s
cert-manager-view                       2s
cert-manager-edit                       2s

==> v1beta1/ClusterRoleBinding
NAME                                 AGE
cert-manager-webhook-ca-sync         2s
cert-manager-webhook:auth-delegator  2s
cert-manager                         2s

==> v1beta1/RoleBinding
NAME                                                AGE
cert-manager-webhook:webhook-authentication-reader  2s

==> v1beta1/Deployment
NAME                  DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
cert-manager-webhook  1        1        1           0          2s
cert-manager          1        1        1           0          2s

==> v1beta1/CronJob
NAME                          SCHEDULE  SUSPEND  ACTIVE  LAST SCHEDULE  AGE
cert-manager-webhook-ca-sync  @weekly   False    0       <none>         2s

==> v1alpha1/Certificate
NAME                              AGE
cert-manager-webhook-webhook-tls  2s
cert-manager-webhook-ca           2s


NOTES:
cert-manager has been deployed successfully!

In order to begin issuing certificates, you will need to set up a ClusterIssuer
or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).

More information on the different types of issuers and how to configure them
can be found in our documentation:

https://cert-manager.readthedocs.io/en/latest/reference/issuers.html

For information on how to configure cert-manager to automatically provision
Certificates for Ingress resources, take a look at the `ingress-shim`
documentation:

https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html


2019/04/06 22:17:57 0 customresourcedefinition.apiextensions.k8s.io/certificates.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/issuers.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/clusterissuers.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/orders.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/challenges.certmanager.k8s.io created
NAME:   cert-manager
LAST DEPLOYED: Sat Apr  6 22:17:55 2019
NAMESPACE: cert-manager
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME                  TYPE       CLUSTER-IP      EXTERNAL-IP  PORT(S)  AGE
cert-manager-webhook  ClusterIP  10.101.238.134  <none>       443/TCP  2s

==> v1/ServiceAccount
NAME                          SECRETS  AGE
cert-manager-webhook-ca-sync  1        2s
cert-manager-webhook          1        2s
cert-manager                  1        2s

==> v1/Pod(related)
NAME                                   READY  STATUS             RESTARTS  AGE
cert-manager-webhook-67cfb86d56-c9dpp  0/1    ContainerCreating  0         2s
cert-manager-67884fcbfc-p9zgl          0/1    ContainerCreating  0         2s
cert-manager-webhook-ca-sync-n6rvm     0/1    ContainerCreating  0         2s

==> v1/ConfigMap
NAME                          DATA  AGE
cert-manager-webhook-ca-sync  1     2s

==> v1/Job
NAME                          COMPLETIONS  DURATION  AGE
cert-manager-webhook-ca-sync  0/1          2s        2s

==> v1beta1/APIService
NAME                                  AGE
v1beta1.admission.certmanager.k8s.io  2s

==> v1alpha1/Issuer
NAME                           AGE
cert-manager-webhook-ca        1s
cert-manager-webhook-selfsign  1s

==> v1beta1/ValidatingWebhookConfiguration
NAME                  AGE
cert-manager-webhook  1s

==> v1beta1/ClusterRole
NAME                          AGE
cert-manager-webhook-ca-sync  2s
cert-manager                  2s

==> v1/ClusterRole
NAME                                    AGE
cert-manager-webhook:webhook-requester  2s
cert-manager-view                       2s
cert-manager-edit                       2s

==> v1beta1/ClusterRoleBinding
NAME                                 AGE
cert-manager-webhook-ca-sync         2s
cert-manager-webhook:auth-delegator  2s
cert-manager                         2s

==> v1beta1/RoleBinding
NAME                                                AGE
cert-manager-webhook:webhook-authentication-reader  2s

==> v1beta1/Deployment
NAME                  DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
cert-manager-webhook  1        1        1           0          2s
cert-manager          1        1        1           0          2s

==> v1beta1/CronJob
NAME                          SCHEDULE  SUSPEND  ACTIVE  LAST SCHEDULE  AGE
cert-manager-webhook-ca-sync  @weekly   False    0       <none>         2s

==> v1alpha1/Certificate
NAME                              AGE
cert-manager-webhook-webhook-tls  2s
cert-manager-webhook-ca           2s


NOTES:
cert-manager has been deployed successfully!

In order to begin issuing certificates, you will need to set up a ClusterIssuer
or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).

More information on the different types of issuers and how to configure them
can be found in our documentation:

https://cert-manager.readthedocs.io/en/latest/reference/issuers.html

For information on how to configure cert-manager to automatically provision
Certificates for Ingress resources, take a look at the `ingress-shim`
documentation:

https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html


2019/04/06 22:17:57 Creating secrets for functions to consume
exec:  scripts/create-functions-auth.sh
res: secret/basic-auth-user created
secret/basic-auth-password created

2019/04/06 22:17:58 secret/basic-auth-user created
secret/basic-auth-password created

2019/04/06 22:17:58
2019/04/06 22:17:58 Creating OpenFaaS
exec:  scripts/install-openfaas.sh
res: "openfaas" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈
Release "openfaas" does not exist. Installing it now.
NAME:   openfaas
LAST DEPLOYED: Sat Apr  6 22:18:01 2019
NAMESPACE: openfaas
STATUS: DEPLOYED

RESOURCES:
==> v1beta1/RoleBinding
NAME                 AGE
openfaas-controller  5s

==> v1beta1/Deployment
NAME          DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
alertmanager  1        1        1           0          5s
faas-idler    1        1        1           0          5s
gateway       2        2        2           0          5s
nats          1        1        1           0          5s
prometheus    1        1        1           0          4s
queue-worker  2        2        2           0          4s

==> v1/ConfigMap
NAME                 DATA  AGE
alertmanager-config  1     5s
prometheus-config    2     5s

==> v1/Role
NAME                 AGE
openfaas-prometheus  5s

==> v1/RoleBinding
NAME                 AGE
openfaas-prometheus  5s

==> v1/Service
NAME              TYPE       CLUSTER-IP      EXTERNAL-IP  PORT(S)         AGE
alertmanager      ClusterIP  10.109.227.229  <none>       9093/TCP        5s
gateway-external  NodePort   10.98.34.191    <none>       8080:31112/TCP  5s
gateway           ClusterIP  10.106.127.87   <none>       8080/TCP        5s
nats              ClusterIP  10.97.223.27    <none>       4222/TCP        5s
prometheus        ClusterIP  10.101.221.10   <none>       9090/TCP        5s

==> v1beta1/Ingress
NAME              HOSTS                   ADDRESS  PORTS  AGE
openfaas-ingress  gateway.openfaas.local  80       4s

==> v1/Pod(related)
NAME                           READY  STATUS             RESTARTS  AGE
alertmanager-8447d8c7df-bmfwg  0/1    ContainerCreating  0         5s
faas-idler-7945c9bc7b-xmnnm    0/1    ContainerCreating  0         5s
gateway-5d77b675df-87s62       0/2    ContainerCreating  0         4s
gateway-5d77b675df-mtqbb       0/2    ContainerCreating  0         4s
nats-6686bb4b95-l6zqw          0/1    ContainerCreating  0         4s
prometheus-5cfc67557b-hzm2p    0/1    ContainerCreating  0         4s
queue-worker-7f4db88854-89cfv  0/1    ContainerCreating  0         4s
queue-worker-7f4db88854-qdztg  0/1    ContainerCreating  0         3s

==> v1/ServiceAccount
NAME                 SECRETS  AGE
openfaas-controller  1        5s
openfaas-prometheus  1        5s

==> v1beta1/Role
NAME                 AGE
openfaas-controller  5s


NOTES:
To verify that openfaas has started, run:

  kubectl --namespace=openfaas get deployments -l "release=openfaas, app=openfaas"


2019/04/06 22:18:06 0 "openfaas" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈
Release "openfaas" does not exist. Installing it now.
NAME:   openfaas
LAST DEPLOYED: Sat Apr  6 22:18:01 2019
NAMESPACE: openfaas
STATUS: DEPLOYED

RESOURCES:
==> v1beta1/RoleBinding
NAME                 AGE
openfaas-controller  5s

==> v1beta1/Deployment
NAME          DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
alertmanager  1        1        1           0          5s
faas-idler    1        1        1           0          5s
gateway       2        2        2           0          5s
nats          1        1        1           0          5s
prometheus    1        1        1           0          4s
queue-worker  2        2        2           0          4s

==> v1/ConfigMap
NAME                 DATA  AGE
alertmanager-config  1     5s
prometheus-config    2     5s

==> v1/Role
NAME                 AGE
openfaas-prometheus  5s

==> v1/RoleBinding
NAME                 AGE
openfaas-prometheus  5s

==> v1/Service
NAME              TYPE       CLUSTER-IP      EXTERNAL-IP  PORT(S)         AGE
alertmanager      ClusterIP  10.109.227.229  <none>       9093/TCP        5s
gateway-external  NodePort   10.98.34.191    <none>       8080:31112/TCP  5s
gateway           ClusterIP  10.106.127.87   <none>       8080/TCP        5s
nats              ClusterIP  10.97.223.27    <none>       4222/TCP        5s
prometheus        ClusterIP  10.101.221.10   <none>       9090/TCP        5s

==> v1beta1/Ingress
NAME              HOSTS                   ADDRESS  PORTS  AGE
openfaas-ingress  gateway.openfaas.local  80       4s

==> v1/Pod(related)
NAME                           READY  STATUS             RESTARTS  AGE
alertmanager-8447d8c7df-bmfwg  0/1    ContainerCreating  0         5s
faas-idler-7945c9bc7b-xmnnm    0/1    ContainerCreating  0         5s
gateway-5d77b675df-87s62       0/2    ContainerCreating  0         4s
gateway-5d77b675df-mtqbb       0/2    ContainerCreating  0         4s
nats-6686bb4b95-l6zqw          0/1    ContainerCreating  0         4s
prometheus-5cfc67557b-hzm2p    0/1    ContainerCreating  0         4s
queue-worker-7f4db88854-89cfv  0/1    ContainerCreating  0         4s
queue-worker-7f4db88854-qdztg  0/1    ContainerCreating  0         3s

==> v1/ServiceAccount
NAME                 SECRETS  AGE
openfaas-controller  1        5s
openfaas-prometheus  1        5s

==> v1beta1/Role
NAME                 AGE
openfaas-controller  5s


NOTES:
To verify that openfaas has started, run:

  kubectl --namespace=openfaas get deployments -l "release=openfaas, app=openfaas"


2019/04/06 22:18:06 Is cert-manager rolled out?
exec:  ./scripts/get-cert-manager.sh
res: Waiting for deployment "cert-manager-webhook" rollout to finish: 0 of 1 updated replicas are available...
deployment "cert-manager-webhook" successfully rolled out

cert-manager 0 Waiting for deployment "cert-manager-webhook" rollout to finish: 0 of 1 updated replicas are available...
deployment "cert-manager-webhook" successfully rolled out
 error: no kind "Certificate" is registered for version "certmanager.k8s.io/v1alpha1" in scheme "k8s.io/kubernetes/pkg/kubectl/scheme/scheme.go:28"
 <nil>
exec:  kubectl apply -f tmp/generated-ingress-ingress-wildcard.yaml
res: ingress.extensions/openfaas-ingress configured

2019/04/06 22:18:31 0 ingress.extensions/openfaas-ingress configured
 Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply

exec:  kubectl apply -f tmp/generated-ingress-ingress.yaml
res: ingress.extensions/openfaas-auth-ingress created

2019/04/06 22:18:32 0 ingress.extensions/openfaas-auth-ingress created

exec:  kubectl apply -f tmp/generated-tls-issuer-prod.yml
res: clusterissuer.certmanager.k8s.io/letsencrypt-prod created

2019/04/06 22:18:32 0 clusterissuer.certmanager.k8s.io/letsencrypt-prod created

exec:  kubectl apply -f tmp/generated-tls-issuer-staging.yml
res: clusterissuer.certmanager.k8s.io/letsencrypt-staging created

2019/04/06 22:18:32 0 clusterissuer.certmanager.k8s.io/letsencrypt-staging created

exec:  kubectl apply -f tmp/generated-tls-wildcard-domain-cert.yml
res: certificate.certmanager.k8s.io/wildcard-vs.team-serverless.xyz created

2019/04/06 22:18:32 0 certificate.certmanager.k8s.io/wildcard-vs.team-serverless.xyz created

exec:  kubectl apply -f tmp/generated-tls-auth-domain-cert.yml
res: certificate.certmanager.k8s.io/auth-system-vs.team-serverless.xyz created

2019/04/06 22:18:33 0 certificate.certmanager.k8s.io/auth-system-vs.team-serverless.xyz created

Creating stack.yml
2019/04/06 22:18:33 Creating SealedSecrets
exec:  scripts/install-sealedsecrets.sh
res: SealedSecrets release: v0.7.0
NAME:   ofc-sealedsecrets
LAST DEPLOYED: Sat Apr  6 22:18:35 2019
NAMESPACE: kube-system
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME                              TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)   AGE
ofc-sealedsecrets-sealed-secrets  ClusterIP  10.101.179.11  <none>       8080/TCP  1s

==> v1/Deployment
NAME                              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
ofc-sealedsecrets-sealed-secrets  1        1        1           0          1s

==> v1/ClusterRoleBinding
NAME                              AGE
ofc-sealedsecrets-sealed-secrets  1s

==> v1/Role
NAME                      AGE
sealed-secrets-key-admin  1s

==> v1/RoleBinding
NAME                              AGE
ofc-sealedsecrets-sealed-secrets  1s

==> v1/Pod(related)
NAME                                               READY  STATUS             RESTARTS  AGE
ofc-sealedsecrets-sealed-secrets-74b4b7b9cf-2g42j  0/1    ContainerCreating  0         1s

==> v1/ServiceAccount
NAME                              SECRETS  AGE
ofc-sealedsecrets-sealed-secrets  1        1s

==> v1beta1/CustomResourceDefinition
NAME                       AGE
sealedsecrets.bitnami.com  1s

==> v1/ClusterRole
NAME              AGE
secrets-unsealer  1s


NOTES:
You should now be able to create sealed secrets.

1. Install client-side tool into /usr/local/bin/

GOOS=$(go env GOOS)
GOARCH=$(go env GOARCH)
wget https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/kubeseal-$GOOS-$GOARCH
sudo install -m 755 kubeseal-$GOOS-$GOARCH /usr/local/bin/kubeseal

2. Create a sealed secret file

# note the use of `--dry-run` - this does not create a secret in your cluster
kubectl create secret generic secret-name --dry-run --from-literal=foo=bar -o [json|yaml] | kubeseal --format [json|yaml] > mysealedsecret.[json|yaml]

The file mysealedsecret.[json|yaml] is a commitable file.

If you would rather not need access to the cluster to generate the sealed secret you can run

kubeseal --fetch-cert > mycert.pem

to retrieve the public cert used for encryption and store it locally. You can then run 'kubeseal --cert mycert.pem' instead to use the local cert e.g.

kubectl create secret generic secret-name --dry-run --from-literal=foo=bar -o [json|yaml] | kubeseal --format [json|yaml] --cert mycert.pem > mysealedsecret.[json|yaml]

3. Apply the sealed secret

kubectl create -f mysealedsecret.[json|yaml]

Running 'kubectl get secret secret-name -o [json|yaml]' will show the decrypted secret that was generated from the sealed secret.

Both the SealedSecret and generated Secret must have the same name and namespace.




2019/04/06 22:18:36 SealedSecrets release: v0.7.0
NAME:   ofc-sealedsecrets
LAST DEPLOYED: Sat Apr  6 22:18:35 2019
NAMESPACE: kube-system
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME                              TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)   AGE
ofc-sealedsecrets-sealed-secrets  ClusterIP  10.101.179.11  <none>       8080/TCP  1s

==> v1/Deployment
NAME                              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
ofc-sealedsecrets-sealed-secrets  1        1        1           0          1s

==> v1/ClusterRoleBinding
NAME                              AGE
ofc-sealedsecrets-sealed-secrets  1s

==> v1/Role
NAME                      AGE
sealed-secrets-key-admin  1s

==> v1/RoleBinding
NAME                              AGE
ofc-sealedsecrets-sealed-secrets  1s

==> v1/Pod(related)
NAME                                               READY  STATUS             RESTARTS  AGE
ofc-sealedsecrets-sealed-secrets-74b4b7b9cf-2g42j  0/1    ContainerCreating  0         1s

==> v1/ServiceAccount
NAME                              SECRETS  AGE
ofc-sealedsecrets-sealed-secrets  1        1s

==> v1beta1/CustomResourceDefinition
NAME                       AGE
sealedsecrets.bitnami.com  1s

==> v1/ClusterRole
NAME              AGE
secrets-unsealer  1s


NOTES:
You should now be able to create sealed secrets.

1. Install client-side tool into /usr/local/bin/

GOOS=$(go env GOOS)
GOARCH=$(go env GOARCH)
wget https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/kubeseal-$GOOS-$GOARCH
sudo install -m 755 kubeseal-$GOOS-$GOARCH /usr/local/bin/kubeseal

2. Create a sealed secret file

# note the use of `--dry-run` - this does not create a secret in your cluster
kubectl create secret generic secret-name --dry-run --from-literal=foo=bar -o [json|yaml] | kubeseal --format [json|yaml] > mysealedsecret.[json|yaml]

The file mysealedsecret.[json|yaml] is a commitable file.

If you would rather not need access to the cluster to generate the sealed secret you can run

kubeseal --fetch-cert > mycert.pem

to retrieve the public cert used for encryption and store it locally. You can then run 'kubeseal --cert mycert.pem' instead to use the local cert e.g.

kubectl create secret generic secret-name --dry-run --from-literal=foo=bar -o [json|yaml] | kubeseal --format [json|yaml] --cert mycert.pem > mysealedsecret.[json|yaml]

3. Apply the sealed secret

kubectl create -f mysealedsecret.[json|yaml]

Running 'kubectl get secret secret-name -o [json|yaml]' will show the decrypted secret that was generated from the sealed secret.

Both the SealedSecret and generated Secret must have the same name and namespace.




2019/04/06 22:18:36
2019/04/06 22:18:36 Are SealedSecrets rolled out?
exec:  ./scripts/get-sealedsecretscontroller.sh
res: Waiting for deployment "ofc-sealedsecrets-sealed-secrets" rollout to finish: 0 of 1 updated replicas are available...
deployment "ofc-sealedsecrets-sealed-secrets" successfully rolled out

sealedsecretscontroller 0 Waiting for deployment "ofc-sealedsecrets-sealed-secrets" rollout to finish: 0 of 1 updated replicas are available...
deployment "ofc-sealedsecrets-sealed-secrets" successfully rolled out
  <nil>
exec:  ./scripts/export-sealed-secret-pubcert.sh
.....
  <nil>
exec:  ./scripts/clone-cloud-components.sh
res:
{ Cloning into './tmp/openfaas-cloud'...
 0}
exec:  ./scripts/deploy-cloud-components.sh
res: deployment.apps/of-builder created
service/of-builder created
clusterrole.rbac.authorization.k8s.io/sealed-secrets-manager unchanged
rolebinding.rbac.authorization.k8s.io/manage-sealed-secrets created
deployment.apps/of-auth created
service/auth created
deployment.apps/of-router created
service/of-router created
service/auth unchanged
Creating payload-secret in openfaas-fn
secret/payload-secret created
Fetch templates from repository: https://github.com/openfaas/templates.git at master
Forwarding from 127.0.0.1:31111 -> 8080
Forwarding from [::1]:31111 -> 8080
Checking if OpenFaaS GW is up.
deployment "gateway" successfully rolled out
Calling the OpenFaaS server to validate the credentials...
Handling connection for 31111
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
credentials saved for admin http://127.0.0.1:31111
Deploying: system-github-event.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/system-github-event

Deploying: buildshiprun.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/buildshiprun

Deploying: garbage-collect.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/garbage-collect

Deploying: github-status.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/github-status

Deploying: audit-event.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/audit-event

Deploying: echo.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/echo

Deploying: system-metrics.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/system-metrics

Deploying: github-push.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/github-push

Deploying: git-tar.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/git-tar

Deploying: import-secrets.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/import-secrets

Deploying: pipeline-log.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/pipeline-log

Deploying: list-functions.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/list-functions

Fetch templates from repository: https://github.com/openfaas-incubator/node10-express-template at master
Deploying: system-dashboard.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/system-dashboard

Deploying: system-list-functions.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/system-list-functions


{deployment.apps/of-builder created
service/of-builder created
clusterrole.rbac.authorization.k8s.io/sealed-secrets-manager unchanged
rolebinding.rbac.authorization.k8s.io/manage-sealed-secrets created
deployment.apps/of-auth created
service/auth created
deployment.apps/of-router created
service/of-router created
service/auth unchanged
Creating payload-secret in openfaas-fn
secret/payload-secret created
Fetch templates from repository: https://github.com/openfaas/templates.git at master
Forwarding from 127.0.0.1:31111 -> 8080
Forwarding from [::1]:31111 -> 8080
Checking if OpenFaaS GW is up.
deployment "gateway" successfully rolled out
Calling the OpenFaaS server to validate the credentials...
Handling connection for 31111
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
credentials saved for admin http://127.0.0.1:31111
Deploying: system-github-event.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/system-github-event

Deploying: buildshiprun.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/buildshiprun

Deploying: garbage-collect.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/garbage-collect

Deploying: github-status.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/github-status

Deploying: audit-event.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/audit-event

Deploying: echo.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/echo

Deploying: system-metrics.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/system-metrics

Deploying: github-push.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/github-push

Deploying: git-tar.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/git-tar

Deploying: import-secrets.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/import-secrets

Deploying: pipeline-log.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/pipeline-log

Deploying: list-functions.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/list-functions

Fetch templates from repository: https://github.com/openfaas-incubator/node10-express-template at master
Deploying: system-dashboard.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/system-dashboard

Deploying: system-list-functions.
Handling connection for 31111
Handling connection for 31111

Deployed. 202 Accepted.
URL: http://127.0.0.1:31111/function/system-list-functions

 2019/04/06 22:18:51 Attempting to expand templates from https://github.com/openfaas/templates.git
2019/04/06 22:18:53 Fetched 15 template(s) : [csharp csharp-armhf dockerfile go go-armhf java8 node node-arm64 node-armhf php7 python python-armhf python3 python3-armhf ruby] from https://github.com/openfaas/templates.git
2019/04/06 22:19:04 Attempting to expand templates from https://github.com/openfaas-incubator/node10-express-template
2019/04/06 22:19:05 Fetched 2 template(s) : [node10-express node10-express-armhf] from https://github.com/openfaas-incubator/node10-express-template
 0}
Plan completed in 90.961584 seconds
```
</details>

## Checklist:

I have:

- [ ] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

