### PR TITLE
Replaced loop checks with helm wait operation

### DIFF
--- a/main.go
+++ b/main.go
@@ -169,16 +169,6 @@ func process(plan types.Plan) error {
 			log.Println(tillerErr)
 		}
 
-		retries := 260
-		for i := 0; i < retries; i++ {
-			log.Printf("Is tiller ready? %d/%d\n", i+1, retries)
-			ready := tillerReady()
-			if ready {
-				break
-			}
-			time.Sleep(time.Second * 2)
-		}
-
 		if err := helmRepoUpdate(); err != nil {
 			log.Println(err.Error())
 		}
@@ -217,17 +207,6 @@ func process(plan types.Plan) error {
 			log.Println(ofErr)
 		}
 
-		if plan.TLS {
-			for i := 0; i < retries; i++ {
-				log.Printf("Is cert-manager ready? %d/%d\n", i+1, retries)
-				ready := certManagerReady()
-				if ready {
-					break
-				}
-				time.Sleep(time.Second * 2)
-			}
-		}
-
 		ingressErr := ingress.Apply(plan)
 		if ingressErr != nil {
 			log.Println(ingressErr)
@@ -250,15 +229,6 @@ func process(plan types.Plan) error {
 		sealedSecretsErr := installSealedSecrets()
 		if sealedSecretsErr != nil {
 			log.Println(sealedSecretsErr)
-		}
-
-		for i := 0; i < retries; i++ {
-			log.Printf("Are SealedSecrets ready? %d/%d\n", i+1, retries)
-			ready := sealedSecretsReady()
-			if ready {
-				break
-			}
-			time.Sleep(time.Second * 2)
 		}
 
 		pubCert := exportSealedSecretPubCert()

--- a/scripts/create-tiller.sh
+++ b/scripts/create-tiller.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-helm init --skip-refresh --upgrade --service-account tiller
+helm init --skip-refresh --upgrade --service-account tiller --wait

--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -7,4 +7,5 @@ helm install \
     --name cert-manager \
     --namespace cert-manager \
     --version v0.6.6 \
+    --wait \
     stable/cert-manager

--- a/scripts/install-sealedsecrets.sh
+++ b/scripts/install-sealedsecrets.sh
@@ -5,4 +5,4 @@ release=$(curl -sI https://github.com/bitnami-labs/sealed-secrets/releases/lates
 
 echo "SealedSecrets release: $release"
 
-helm install --namespace kube-system --name ofc-sealedsecrets stable/sealed-secrets
+helm install --namespace kube-system --name ofc-sealedsecrets stable/sealed-secrets --wait


### PR DESCRIPTION
Signed-off-by: Rishabh Gupta <r.g.gupta@outlook.com>

## Description
This PR replaces loop checks with helm wait operations. 

## How Has This Been Tested?
Tested changes on a local cluster. 
The zip file contains ofc-bootstrap binary compiled from this branch and includes scripts and templates. To test this branch extract the contents of zip and provide init.yaml ([example](https://raw.githubusercontent.com/openfaas-incubator/ofc-bootstrap/master/example.init.yaml)) and then run `./ofc-bootstrap`
[ofc-bootstrap.zip](https://github.com/openfaas-incubator/ofc-bootstrap/files/3017761/ofc-bootstrap.zip)

Addresses issue #86 

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests

