### PR TITLE
Convert sed usage to go templates / fix GitLab

### DIFF
--- a/main.go
+++ b/main.go
@@ -268,12 +268,12 @@ func process(plan types.Plan) error {
 		}
 
 		cloneErr := cloneCloudComponents()
-		if (cloneErr) != nil {
+		if cloneErr != nil {
 			return cloneErr
 		}
 
 		deployErr := deployCloudComponents(plan)
-		if (deployErr) != nil {
+		if deployErr != nil {
 			return deployErr
 		}
 	}

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -65,7 +65,6 @@ func Apply(plan types.Plan) error {
 		if gitlabConfigErr != nil {
 			return gitlabConfigErr
 		}
-
 	}
 
 	dashboardConfigErr := generateTemplate("dashboard_config", plan, gatewayConfig{
@@ -89,7 +88,21 @@ func Apply(plan types.Plan) error {
 		}
 	}
 
+	isGitHub := plan.SCM == "github"
+
+	stackErr := generateTemplate("stack", plan, stackConfig{
+		GitHub: isGitHub,
+	})
+
+	if stackErr != nil {
+		return stackErr
+	}
+
 	return nil
+}
+
+type stackConfig struct {
+	GitHub bool
 }
 
 func applyTemplate(templateFileName string, templateType interface{}) ([]byte, error) {

--- a/scripts/clone-cloud-components.sh
+++ b/scripts/clone-cloud-components.sh
@@ -3,3 +3,4 @@
 rm -rf ./tmp/openfaas-cloud
 
 git clone https://github.com/openfaas/openfaas-cloud ./tmp/openfaas-cloud
+

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -56,15 +56,7 @@ done
 export OPENFAAS_URL=http://127.0.0.1:31111
 echo -n $ADMIN_PASSWORD | faas-cli login --username admin --password-stdin
 
-if [ "$GITLAB" = "true" ] ; then
-
-# Suppress errors by removing secrets for GitHub
-
-    sed -i '' s/\-\ private-key/#\-\ private-key/g stack.yml
-    sed -i '' s/\#\-\ gitlab-api-token/\-\ gitlab-api-token/g stack.yml
-    sed -i '' s/\-\ github-webhook-secret/#\-\ github-webhook-secret/g stack.yml
-
-fi
+cp ../generated-stack.yml ./stack.yml
 
 faas-cli deploy
 

--- a/templates/gitlab.yml
+++ b/templates/gitlab.yml
@@ -74,5 +74,4 @@ functions:
       - github.yml
     secrets:
       - payload-secret
-      - private-key
       - gitlab-api-token

--- a/templates/stack.yml
+++ b/templates/stack.yml
@@ -1,0 +1,212 @@
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  {{ if .GitHub }}
+  system-github-event:
+    lang: go
+    handler: ./github-event
+    image: functions/github-event:0.7.2
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      validate_hmac: true
+      write_debug: true
+      read_debug: true
+      validate_customers: true
+    environment_file:
+      - github.yml
+      - gateway_config.yml
+    secrets:
+      - github-webhook-secret
+      - payload-secret
+
+  github-push:
+    lang: go
+    handler: ./github-push
+    image: functions/github-push:0.7.1
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      validate_hmac: true
+      read_timeout: 10s
+      write_timeout: 10s
+      write_debug: true
+      read_debug: true
+    environment_file:
+      - gateway_config.yml
+      - github.yml
+    secrets:
+      - github-webhook-secret
+      - payload-secret
+    {{ end }}
+
+  git-tar:
+    lang: dockerfile
+    handler: ./git-tar
+    image: functions/of-git-tar:0.9.2
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      read_timeout: 15m
+      write_timeout: 15m
+      write_debug: true
+      read_debug: true
+    environment_file:
+      - gateway_config.yml
+      - github.yml
+    secrets:
+      - payload-secret
+    {{ if .GitHub }}
+      - private-key
+    {{ end }}
+# Uncomment this for GitLab
+    {{ if not .GitHub }}
+      - gitlab-api-token
+    {{ end }}
+
+  buildshiprun:
+    lang: go
+    handler: ./buildshiprun
+    image: functions/of-buildshiprun:0.9.3
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      read_timeout: 5m
+      write_timeout: 5m
+      write_debug: true
+      read_debug: true
+      scaling_factor: 50
+    environment_file:
+      - buildshiprun_limits.yml
+      - gateway_config.yml
+      - github.yml
+    secrets:
+      - basic-auth-user
+      - basic-auth-password
+      - payload-secret
+#      - swarm-pull-secret
+
+  garbage-collect:
+    lang: go
+    handler: ./garbage-collect
+    image: functions/garbage-collect:0.4.3
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      write_debug: true
+      read_debug: true
+      read_timeout: 30s
+      write_timeout: 30s
+    environment_file:
+      - gateway_config.yml
+    secrets:
+      - basic-auth-user
+      - basic-auth-password
+      - payload-secret
+
+  {{ if .GitHub }}
+  github-status:
+    lang: go
+    handler: ./github-status
+    image: functions/github-status:0.3.5
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      write_debug: true
+      read_debug: true
+      combine_output: false
+      validate_hmac: true
+      debug_token: true
+    environment_file:
+      - gateway_config.yml
+      - github.yml
+    secrets:
+      - private-key
+      - payload-secret
+  {{ end }}
+
+  import-secrets:
+    lang: go
+    handler: ./import-secrets
+    image: functions/import-secrets:0.3.2
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      write_debug: true
+      read_debug: true
+      validate_hmac: true
+      combined_output: false
+    environment_file:
+      - github.yml
+    secrets:
+      - payload-secret
+
+  pipeline-log:
+    lang: go
+    handler: ./pipeline-log
+    image: functions/pipeline-log:0.3.2
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      write_debug: true
+      read_debug: true
+      combine_output: false
+    environment_file:
+      - gateway_config.yml
+    secrets:
+      - s3-access-key
+      - s3-secret-key
+      - payload-secret
+
+  list-functions:
+    lang: go
+    handler: ./list-functions
+    image: functions/list-functions:0.4.7
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      write_debug: true
+      read_debug: true
+    environment_file:
+      - gateway_config.yml
+    secrets:
+      - basic-auth-user
+      - basic-auth-password
+
+  audit-event:
+    lang: go
+    handler: ./audit-event
+    image: functions/audit-event:0.1.1
+    labels:
+      openfaas-cloud: "1"
+    environment_file:
+      - slack.yml
+
+  echo:
+    skip_build: true
+    image: functions/alpine:latest
+    fprocess: cat
+    environment:
+      write_debug: true
+      read_debug: true
+
+  system-metrics:
+    lang: go
+    handler: ./system-metrics
+    image: functions/system-metrics:0.1.0
+    environment_file:
+      - gateway_config.yml
+    environment:
+      content_type: "application/json"
+


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

## Description

- fixes issues with sed working differently on Mac/Linux
- replaces use of sed with go templates to remove GitHub secrets
when using GitLab as the SCM
- removes "private-key" GitHub secret from the gitlab.yml file
which was preventing deployments

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on a Linux host with GitLab set to true, functions created as expected.

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
