### PR TITLE
Add support for dockerfile template. Fixes #94

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ kubectl apply -f ./tmp/generated-tls-auth-domain-cert.yml
 kubectl apply -f ./tmp/generated-tls-wildcard-domain-cert.yml
 ```
 
+#### Enable dockerfile language support (optional)
+If you are planning on building functions using the `dockerfile` template you need to set `enable_dockerfile_lang: true`.
+
 ### Run the `ofc-bootstrap`
 
 ```bash

--- a/example.init.yaml
+++ b/example.init.yaml
@@ -233,3 +233,6 @@ tls_config:
   # dns_service: route53
   # region: us-east-1
   # access_key_id: ASYAKIUJE8AYRQQ7DU3M
+
+# Dockerfile language support
+enable_dockerfile_lang: false

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -10,12 +10,13 @@ import (
 )
 
 type gatewayConfig struct {
-	Registry        string
-	RootDomain      string
-	CustomersURL    string
-	Scheme          string
-	S3              types.S3
-	CustomTemplates string
+	Registry             string
+	RootDomain           string
+	CustomersURL         string
+	Scheme               string
+	S3                   types.S3
+	CustomTemplates      string
+	EnableDockerfileLang bool
 }
 
 type authConfig struct {
@@ -35,12 +36,13 @@ func Apply(plan types.Plan) error {
 	}
 
 	gwConfigErr := generateTemplate("gateway_config", plan, gatewayConfig{
-		Registry:        plan.Registry,
-		RootDomain:      plan.RootDomain,
-		CustomersURL:    plan.CustomersURL,
-		Scheme:          scheme,
-		S3:              plan.S3,
-		CustomTemplates: plan.Deployment.FormatCustomTemplates(),
+		Registry:             plan.Registry,
+		RootDomain:           plan.RootDomain,
+		CustomersURL:         plan.CustomersURL,
+		Scheme:               scheme,
+		S3:                   plan.S3,
+		CustomTemplates:      plan.Deployment.FormatCustomTemplates(),
+		EnableDockerfileLang: plan.EnableDockerfileLang,
 	})
 
 	if gwConfigErr != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -34,23 +34,24 @@ const (
 )
 
 type Plan struct {
-	Features      []string                 `yaml:"features"`
-	Orchestration string                   `yaml:"orchestration"`
-	Secrets       []KeyValueNamespaceTuple `yaml:"secrets"`
-	RootDomain    string                   `yaml:"root_domain"`
-	Registry      string                   `yaml:"registry"`
-	CustomersURL  string                   `yaml:"customers_url"`
-	SCM           string                   `yaml:"scm"`
-	Github        Github                   `yaml:"github"`
-	Gitlab        Gitlab                   `yaml:"gitlab"`
-	TLS           bool                     `yaml:"tls"`
-	OAuth         OAuth                    `yaml:"oauth"`
-	S3            S3                       `yaml:"s3"`
-	EnableOAuth   bool                     `yaml:"enable_oauth"`
-	TLSConfig     TLSConfig                `yaml:"tls_config"`
-	Slack         Slack                    `yaml:"slack"`
-	Ingress       string                   `yaml:"ingress"`
-	Deployment    Deployment               `yaml:"deployment"`
+	Features             []string                 `yaml:"features"`
+	Orchestration        string                   `yaml:"orchestration"`
+	Secrets              []KeyValueNamespaceTuple `yaml:"secrets"`
+	RootDomain           string                   `yaml:"root_domain"`
+	Registry             string                   `yaml:"registry"`
+	CustomersURL         string                   `yaml:"customers_url"`
+	SCM                  string                   `yaml:"scm"`
+	Github               Github                   `yaml:"github"`
+	Gitlab               Gitlab                   `yaml:"gitlab"`
+	TLS                  bool                     `yaml:"tls"`
+	OAuth                OAuth                    `yaml:"oauth"`
+	S3                   S3                       `yaml:"s3"`
+	EnableOAuth          bool                     `yaml:"enable_oauth"`
+	TLSConfig            TLSConfig                `yaml:"tls_config"`
+	Slack                Slack                    `yaml:"slack"`
+	Ingress              string                   `yaml:"ingress"`
+	Deployment           Deployment               `yaml:"deployment"`
+	EnableDockerfileLang bool                     `yaml:"enable_dockerfile_lang"`
 }
 
 // Deployment is the deployment section of YAML concerning

--- a/templates/gateway_config.yml
+++ b/templates/gateway_config.yml
@@ -33,3 +33,6 @@ environment:
   prometheus_host: prometheus.openfaas
   prometheus_port: 9090
   metrics_window: 60m
+
+# Dockerfile language support
+  enable_dockerfile_lang: {{.EnableDockerfileLang}}


### PR DESCRIPTION
Signed-off-by: Matias Pan <matias.pan26@gmail.com>

## Description
Support for dockerfile templates was added to OpenFaaS Cloud via [PR #422](https://github.com/openfaas/openfaas-cloud/pull/422), this PR makes the configuration available from ofc bootstrap.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested deploying a new OpenFaaS Cloud cluster to GKE and installing the GitHub app on [matipan/dtest](https://github.com/matipan/dtest). [Here](https://github.com/matipan/dtest/runs/89533085) you can see that OFC was able to build and deploy the function.

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
