### PR TITLE
Bumping versions of functions

### DIFF
--- a/templates/gitlab.yml
+++ b/templates/gitlab.yml
@@ -6,10 +6,11 @@ functions:
   system-gitlab-event:
     lang: go
     handler: ./gitlab-event
-    image: functions/gitlab-event:0.1.1
+    image: functions/gitlab-event:0.1.2
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       content_type: text/plain
       validate_customers: true
@@ -23,15 +24,16 @@ functions:
     secrets:
       - gitlab-webhook-secret
       - payload-secret
-      - gitlab-api-token 
+      - gitlab-api-token
 
   gitlab-status:
     lang: go
     handler: ./gitlab-status
-    image: functions/gitlab-status:0.1.0
+    image: functions/gitlab-status:0.1.1
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       write_debug: true
       read_debug: true
@@ -39,15 +41,16 @@ functions:
       - gateway_config.yml
     secrets:
       - gitlab-api-token
-      - payload-secret 
-      
+      - payload-secret
+
   gitlab-push:
     lang: go
     handler: ./gitlab-push
-    image: functions/gitlab-push:0.2.0
+    image: functions/gitlab-push:0.2.1
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       write_debug: true
       read_debug: true
@@ -60,10 +63,11 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.9.1
+    image: functions/of-git-tar:0.11.1
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       read_timeout: 15m
       write_timeout: 15m

--- a/templates/stack.yml
+++ b/templates/stack.yml
@@ -7,10 +7,11 @@ functions:
   system-github-event:
     lang: go
     handler: ./github-event
-    image: functions/github-event:0.7.3
+    image: functions/github-event:0.7.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       validate_hmac: true
       write_debug: true
@@ -26,10 +27,11 @@ functions:
   github-push:
     lang: go
     handler: ./github-push
-    image: functions/github-push:0.7.1
+    image: functions/github-push:0.7.2
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       validate_hmac: true
       read_timeout: 10s
@@ -47,10 +49,11 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.9.2
+    image: functions/of-git-tar:0.11.1
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       read_timeout: 15m
       write_timeout: 15m
@@ -72,10 +75,11 @@ functions:
   buildshiprun:
     lang: go
     handler: ./buildshiprun
-    image: functions/of-buildshiprun:0.9.3
+    image: functions/of-buildshiprun:0.10.3
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       read_timeout: 5m
       write_timeout: 5m
@@ -95,10 +99,11 @@ functions:
   garbage-collect:
     lang: go
     handler: ./garbage-collect
-    image: functions/garbage-collect:0.4.3
+    image: functions/garbage-collect:0.4.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       write_debug: true
       read_debug: true
@@ -115,10 +120,11 @@ functions:
   github-status:
     lang: go
     handler: ./github-status
-    image: functions/github-status:0.3.5
+    image: functions/github-status:0.3.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       write_debug: true
       read_debug: true
@@ -136,10 +142,11 @@ functions:
   import-secrets:
     lang: go
     handler: ./import-secrets
-    image: functions/import-secrets:0.3.2
+    image: functions/import-secrets:0.3.3
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       write_debug: true
       read_debug: true
@@ -153,10 +160,11 @@ functions:
   pipeline-log:
     lang: go
     handler: ./pipeline-log
-    image: functions/pipeline-log:0.3.2
+    image: functions/pipeline-log:0.3.3
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       write_debug: true
       read_debug: true
@@ -171,10 +179,11 @@ functions:
   list-functions:
     lang: go
     handler: ./list-functions
-    image: functions/list-functions:0.4.7
+    image: functions/list-functions:0.4.8
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
+      com.openfaas.scale.zero: false
     environment:
       write_debug: true
       read_debug: true
@@ -187,15 +196,18 @@ functions:
   audit-event:
     lang: go
     handler: ./audit-event
-    image: functions/audit-event:0.1.1
+    image: functions/audit-event:0.1.2
     labels:
       openfaas-cloud: "1"
+      com.openfaas.scale.zero: false
     environment_file:
       - slack.yml
 
   echo:
     skip_build: true
     image: functions/alpine:latest
+    labels:
+      com.openfaas.scale.zero: false
     fprocess: cat
     environment:
       write_debug: true
@@ -204,7 +216,9 @@ functions:
   system-metrics:
     lang: go
     handler: ./system-metrics
-    image: functions/system-metrics:0.1.0
+    image: functions/system-metrics:0.1.1
+    labels:
+      com.openfaas.scale.zero: false
     environment_file:
       - gateway_config.yml
     environment:


### PR DESCRIPTION
Bumping versions of functions which are using
the new watchdog and disabling scale from zero
by applying the label

Signed-off-by: Martin Dekov <mdekov@vmware.com>

## Description

Closes #98 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N/A

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

