### PR TITLE
Add scale_to_zero option to enable scale to zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ kubectl apply -f ./tmp/generated-tls-wildcard-domain-cert.yml
 #### Enable dockerfile language support (optional)
 If you are planning on building functions using the `dockerfile` template you need to set `enable_dockerfile_lang: true`.
 
+#### Enable scaling to zero
+If you want your functions to scale to zero then you need to set `scale_to_zero: true`.
+
 ### Run the `ofc-bootstrap`
 
 ```bash

--- a/example.init.yaml
+++ b/example.init.yaml
@@ -238,3 +238,6 @@ tls_config:
 
 # Dockerfile language support
 enable_dockerfile_lang: false
+
+# Set to true to enable scaling to zero
+scale_to_zero: false

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/openfaas-incubator/ofc-bootstrap/pkg/execute"
@@ -212,7 +213,7 @@ func process(plan types.Plan) error {
 			log.Println(functionAuthErr.Error())
 		}
 
-		ofErr := installOpenfaas()
+		ofErr := installOpenfaas(plan.ScaleToZero)
 		if ofErr != nil {
 			log.Println(ofErr)
 		}
@@ -400,12 +401,13 @@ func installSealedSecrets() error {
 	return nil
 }
 
-func installOpenfaas() error {
+func installOpenfaas(scaleToZero bool) error {
 	log.Println("Creating OpenFaaS")
 
 	task := execute.ExecTask{
 		Command: "scripts/install-openfaas.sh",
 		Shell:   true,
+		Env:     []string{fmt.Sprintf("FAAS_IDLER_DRY_RUN=%v", strconv.FormatBool(!scaleToZero))},
 	}
 
 	res, err := task.Execute()

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -52,6 +52,7 @@ type Plan struct {
 	Ingress              string                   `yaml:"ingress"`
 	Deployment           Deployment               `yaml:"deployment"`
 	EnableDockerfileLang bool                     `yaml:"enable_dockerfile_lang"`
+	ScaleToZero          bool                     `yaml:"scale_to_zero"`
 }
 
 // Deployment is the deployment section of YAML concerning

--- a/scripts/install-openfaas.sh
+++ b/scripts/install-openfaas.sh
@@ -17,5 +17,5 @@ helm upgrade openfaas --install openfaas/openfaas \
     --set faasnetes.writeTimeout=5m \
     --set gateway.replicas=2 \
     --set queueWorker.replicas=2 \
-    --set faasIdler.dryRun=true \
+    --set faasIdler.dryRun=$FAAS_IDLER_DRY_RUN \
     --set faasnetes.httpProbe=false


### PR DESCRIPTION
Signed-off-by: Matias Pan <matias.pan26@gmail.com>

## Description
A flag called `scale_to_zero` was added to the `example_init.yaml` file. If the flag is set to true then we enable the faas-idler(i.e dryRun=false). If it's false(default behaviour) then the faas-idler is disabled(i.e dryRun=true).

Fixes #97 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created a GKE cluster and executed the script, first with the flag set to true:
![faas-idler-false](https://user-images.githubusercontent.com/8126891/56830928-1c165f00-683e-11e9-8513-46aee1602505.png)

And then with the flag set to false:
![faas-idler-true](https://user-images.githubusercontent.com/8126891/56830934-2173a980-683e-11e9-8382-33e36cbc3f74.png)

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

