### PR TITLE
Move to edge-prefix for auth/router

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: go
 go:
-- 1.10.x
+- 1.11.x
 services:
 - docker
 addons:

--- a/example.init.yaml
+++ b/example.init.yaml
@@ -241,4 +241,4 @@ enable_dockerfile_lang: false
 
 # Set to true to enable scaling to zero
 scale_to_zero: false
-openfaas_cloud_version: 0.8.11
+openfaas_cloud_version: 0.9.0

--- a/hack/install-ci.sh
+++ b/hack/install-ci.sh
@@ -19,4 +19,6 @@ sudo apt-get install -y kubectl
 
 curl -sLSf https://raw.githubusercontent.com/helm/helm/master/scripts/get | sudo bash
 
+export GO111MODULE="on"
+
 go get sigs.k8s.io/kind

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -80,7 +80,7 @@ func Apply(plan types.Plan) error {
 	}
 
 	if plan.EnableOAuth {
-		ofAuthDepErr := generateTemplate("of-auth-dep", plan, authConfig{
+		ofAuthDepErr := generateTemplate("edge-auth-dep", plan, authConfig{
 			RootDomain:           plan.RootDomain,
 			ClientId:             plan.OAuth.ClientId,
 			CustomersURL:         plan.CustomersURL,

--- a/pkg/stack/stack_test.go
+++ b/pkg/stack/stack_test.go
@@ -18,7 +18,7 @@ func Test_applyTemplateWithAuth(t *testing.T) {
 		Scheme:       "http",
 	}
 
-	templateFileName := "../../templates/of-auth-dep.yml"
+	templateFileName := "../../templates/edge-auth-dep.yml"
 
 	generatedValue, err := applyTemplate(templateFileName, templateValues)
 

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -11,17 +11,17 @@ kubectl apply -f ./tmp/openfaas-cloud/yaml/core/of-builder-svc.yml
 kubectl apply -f ./tmp/openfaas-cloud/yaml/core/rbac-import-secrets.yml
 
 if [ "$ENABLE_OAUTH" = "true" ] ; then
-    cp ./tmp/generated-of-auth-dep.yml ./tmp/openfaas-cloud/yaml/core/of-auth-dep.yml
-    kubectl apply -f ./tmp/openfaas-cloud/yaml/core/of-auth-dep.yml
-    kubectl apply -f ./tmp/openfaas-cloud/yaml/core/of-auth-svc.yml
-    kubectl apply -f ./tmp/openfaas-cloud/yaml/core/of-router-dep.yml
+    cp ./tmp/generated-edge-auth-dep.yml ./tmp/openfaas-cloud/yaml/core/edge-auth-dep.yml
+    kubectl apply -f ./tmp/openfaas-cloud/yaml/core/edge-auth-dep.yml
+    kubectl apply -f ./tmp/openfaas-cloud/yaml/core/edge-auth-svc.yml
+    kubectl apply -f ./tmp/openfaas-cloud/yaml/core/edge-router-dep.yml
 else
     #  Disable auth service by pointing the router at the echo function:
-    sed s/auth.openfaas/echo.openfaas-fn/g ./tmp/openfaas-cloud/yaml/core/of-router-dep.yml | kubectl apply -f -
+    sed s/auth.openfaas/echo.openfaas-fn/g ./tmp/openfaas-cloud/yaml/core/edge-router-dep.yml | kubectl apply -f -
 fi
-kubectl apply -f ./tmp/openfaas-cloud/yaml/core/of-router-svc.yml
+kubectl apply -f ./tmp/openfaas-cloud/yaml/core/edge-router-svc.yml
 
-kubectl apply -f ./tmp/openfaas-cloud/yaml/core/of-auth-svc.yml
+kubectl apply -f ./tmp/openfaas-cloud/yaml/core/edge-auth-svc.yml
 
 
 cd ./tmp/openfaas-cloud

--- a/templates/edge-auth-dep.yml
+++ b/templates/edge-auth-dep.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: of-auth
+  name: edge-auth
   namespace: openfaas
 spec:
   replicas: 1
@@ -10,7 +10,7 @@ spec:
       annotations:
         prometheus.io.scrape: "false"
       labels:
-        app: of-auth
+        app: edge-auth
     spec:
       volumes:
         - name: jwt-private-key
@@ -23,8 +23,8 @@ spec:
           secret:
             secretName: of-client-secret
       containers:
-      - name: of-auth
-        image: openfaas/cloud-auth:0.5.2
+      - name: edge-auth
+        image: openfaas/edge-auth:0.5.2
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -45,7 +45,7 @@ spec:
 # Update for your configuration:
           - name: client_secret # this can also be provided via a secret named of-client-secret
             value: ""
-          - name: client_id
+         - name: client_id
             value: "{{.ClientId}}"
           - name: oauth_provider_base_url
             value: "{{.OAuthProviderBaseURL}}"

--- a/templates/k8s/ingress-wildcard.yml
+++ b/templates/k8s/ingress-wildcard.yml
@@ -29,7 +29,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: of-router
+          serviceName: edge-router
           servicePort: 8080
   - host: 'gateway.{{.RootDomain}}'
     http:

--- a/templates/k8s/ingress.yml
+++ b/templates/k8s/ingress.yml
@@ -29,5 +29,5 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: of-router
+          serviceName: edge-router
           servicePort: 8080


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

## Description

This change syncs with the latest changes for the router and auth
services which now have a prefix of edge-.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

TBD once upstream changes are merged in openfaas-cloud repo

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

