### PR TITLE
Restore a previously removed space

### DIFF
--- a/templates/edge-auth-dep.yml
+++ b/templates/edge-auth-dep.yml
@@ -45,7 +45,7 @@ spec:
 # Update for your configuration:
           - name: client_secret # this can also be provided via a secret named of-client-secret
             value: ""
-         - name: client_id
+          - name: client_id
             value: "{{.ClientId}}"
           - name: oauth_provider_base_url
             value: "{{.OAuthProviderBaseURL}}"


### PR DESCRIPTION
Signed-off-by: Matias Pan <matias.pan26@gmail.com>

## Description
Add a space that was previously removed. This fixes an error when deploying the edge-auth component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Use the template to deploy a cluster to GKE.

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

