### PR TITLE
Add network policies change

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ If you are planning on building functions using the `dockerfile` template you ne
 #### Enable scaling to zero
 If you want your functions to scale to zero then you need to set `scale_to_zero: true`.
 
+#### Toggle network policies
+
+Network policies restriction for the openfaas and openfaas-fn namespaces are applied by default. If you would like to remove that restriction set `network_policies: false`.
+
+When deployed, network policies restrict communication so that functions cannot talk to the core OpenFaaS components in the `openfaas` namespace. They also prevent functions from invoking each other directly. It is recommended to enable this feature.
+
 ### Run the `ofc-bootstrap`
 
 ```bash

--- a/example.init.yaml
+++ b/example.init.yaml
@@ -242,3 +242,6 @@ enable_dockerfile_lang: false
 # Set to true to enable scaling to zero
 scale_to_zero: false
 openfaas_cloud_version: 0.9.4
+
+# Enable network policies
+network_policies: true

--- a/main.go
+++ b/main.go
@@ -607,11 +607,15 @@ func deployCloudComponents(plan types.Plan) error {
 	if plan.SCM == "gitlab" {
 		gitlabEnv = "GITLAB=true"
 	}
+	networkPoliciesEnv := ""
+	if plan.NetworkPolicies {
+		networkPoliciesEnv = "ENABLE_NETWORK_POLICIES=true"
+	}
 
 	task := execute.ExecTask{
 		Command: "./scripts/deploy-cloud-components.sh",
 		Shell:   true,
-		Env:     []string{authEnv, gitlabEnv},
+		Env:     []string{authEnv, gitlabEnv, networkPoliciesEnv},
 	}
 
 	res, err := task.Execute()

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -54,6 +54,7 @@ type Plan struct {
 	EnableDockerfileLang bool                     `yaml:"enable_dockerfile_lang"`
 	ScaleToZero          bool                     `yaml:"scale_to_zero"`
 	OpenFaaSCloudVersion string                   `yaml:"openfaas_cloud_version"`
+	NetworkPolicies      bool                     `yaml:"network_policies"`
 }
 
 // Deployment is the deployment section of YAML concerning

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -23,6 +23,9 @@ kubectl apply -f ./tmp/openfaas-cloud/yaml/core/edge-router-svc.yml
 
 kubectl apply -f ./tmp/openfaas-cloud/yaml/core/edge-auth-svc.yml
 
+if [ "$ENABLE_NETWORK_POLICIES" = "true" ] ; then
+    kubectl apply -f ./tmp/openfaas-cloud/yaml/network-policy/
+fi
 
 cd ./tmp/openfaas-cloud
 


### PR DESCRIPTION
Adding network policies restriction to the openfaas and
the openfaas-fn namespaces introduced by Matias in the
openfaas-cloud repo

Signed-off-by: Martin Dekov <mdekov@vmware.com>

## Description

Closes #111 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the bootstrapper in DO Kubernetes cluster:

`network_policies: false`
1. Install busybox in default namespace:
2. wget gateway in openfaas namespace:
![image](https://user-images.githubusercontent.com/34942004/57935811-528a4b80-78cb-11e9-8db3-3bfb4864d963.png)
3. wget pipeline-log in openfaas-fn namespace:
![image](https://user-images.githubusercontent.com/34942004/57935861-6c2b9300-78cb-11e9-8e11-b56b33a5a270.png)

`network_policies: true`
1. Install busybox in default namespace:
2. wget gateway in openfaas namespace:
![image](https://user-images.githubusercontent.com/34942004/57935888-7a79af00-78cb-11e9-8ed8-14e2ebe63463.png)
3. wget pipeline-log in openfaas-fn namespace:
![image](https://user-images.githubusercontent.com/34942004/57935910-81082680-78cb-11e9-933c-f656a50f07fb.png)

## Checklist:

I have:

- [ ] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

