### PR TITLE
Fix perms with kubeseal

### DIFF
--- a/scripts/export-sealed-secret-pubcert.sh
+++ b/scripts/export-sealed-secret-pubcert.sh
@@ -10,7 +10,7 @@ then
 #    release=$(curl --silent "https://api.github.com/repos/bitnami-labs/sealed-secrets/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
     echo "SealedSecrets release: $release"
 
-    curl -sLSf https://github.com/bitnami/sealed-secrets/releases/download/$release/kubeseal-$GOOS-$GOARCH > kubeseal && \
+    curl -sLSf https://github.com/bitnami/sealed-secrets/releases/download/$release/kubeseal-$GOOS-$GOARCH > kubeseal
     chmod +x kubeseal
 fi
 


### PR DESCRIPTION
## Description
When running `./ofc-bootstrap -yaml=init.yaml` for the first time the scripts will download kubeseal and chmod in one line. The indenting on the new line is causing issues, and the `chmod +x` is being ignored. To keep the script readable I just removed the `&& \` 

Fixes #70 

## How Has This Been Tested?
Manually. 
1. Remove kubeseal 
2. exec `./scripts/export-sealed-secret-pubcert.sh`
3. check perms of kubeseal

Only tested on Ubuntu 18.04

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

