### PR TITLE
Missing step in Run Ofc-bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ When deployed, network policies restrict communication so that functions cannot 
 ```bash
 cd $GOPATH/src/github.com/openfaas-incubator/ofc-bootstrap
 
+# compile main.go, only needs to be run once
+go build
+
 ./ofc-bootstrap -yaml=init.yaml
 ```
 


### PR DESCRIPTION
For non-Go coders, having the build step be explicit saves some time and frustration.

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist:

I have:

- [ ] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests

