### PR TITLE
Fix the build errors by installing kubectl

### DIFF
--- a/hack/install-ci.sh
+++ b/hack/install-ci.sh
@@ -11,11 +11,9 @@ echo "export PATH=\$GOPATH/bin:\$PATH:/usr/local/go/bin/" | tee -a ~/.bash_profi
 
 curl -sLSf https://cli.openfaas.com | sudo sh
 
-sudo apt-get update && sudo apt-get install -y apt-transport-https
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-sudo apt-get update
-sudo apt-get install -y kubectl
+curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+chmod +x ./kubectl
+sudo mv ./kubectl /usr/local/bin/kubectl
 
 curl -sLSf https://raw.githubusercontent.com/helm/helm/master/scripts/get | sudo bash
 


### PR DESCRIPTION
Native package management cannot unpack the kubectl archive.
So using curl to get the latest stable release.

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

## Description
The Native package management is failing to unpack kubectl.
So trying to fetch the binary with curl to see if it helps with the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

