### PR TITLE
Add ECR support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ofc-bootstrap.exe
 init.yaml
 main
 bin/
+config.json

--- a/example.init.yaml
+++ b/example.init.yaml
@@ -270,7 +270,7 @@ enable_dockerfile_lang: false
 scale_to_zero: false
 
 ## Version of OpenFaaS Cloud from https://github.com/openfaas/openfaas-cloud/releases/
-openfaas_cloud_version: 0.10.0
+openfaas_cloud_version: 0.11.0
 
 ## Enable network policies
 ### Prevents functions from talking to the openfaas namespace, and to each other.

--- a/example.init.yaml
+++ b/example.init.yaml
@@ -136,6 +136,7 @@ secrets:
     filters:
       - "default"
     namespace: "openfaas"
+
   # Used to pull functions / images to nodes by Kubernetes
   - name: "registry-pull-secret"
     files:
@@ -146,6 +147,17 @@ secrets:
       - "default"
     type: "kubernetes.io/dockerconfigjson"
 
+    # ECR credentials to push to AWS ECR
+    ## Make sure you do not use your admin account in ~/.aws/credentials, but a
+    ## new user with ECR power-user permissions only.
+  - name: "ecr-credentials"
+    files:
+      - name: "credentials"
+        value_from: "~/.aws/credentials"
+    filters:
+      - "ecr"
+    namespace: "openfaas"
+
 ### Docker registry
 #### This can be any cluster accessible by your cluster. To populate the file
 #### run `docker login` with "store in keychain" turned off in Docker Desktop.
@@ -153,6 +165,9 @@ secrets:
 #### Format: registry/username/ - i.e. replace ofctest with your login
 
 registry: docker.io/ofctest/
+
+### Enable only if using AWS ECR
+enable_ecr: false
 
 ### Your root DNS domain name, this can be a sub-domain i.e. staging.o6s.io / prod.o6s.io
 root_domain: "myfaas.club"

--- a/main.go
+++ b/main.go
@@ -604,19 +604,30 @@ func deployCloudComponents(plan types.Plan) error {
 	if plan.EnableOAuth {
 		authEnv = "ENABLE_OAUTH=true"
 	}
+
 	gitlabEnv := ""
 	if plan.SCM == "gitlab" {
 		gitlabEnv = "GITLAB=true"
 	}
+
 	networkPoliciesEnv := ""
 	if plan.NetworkPolicies {
 		networkPoliciesEnv = "ENABLE_NETWORK_POLICIES=true"
 	}
 
+	enableECREnv := ""
+	if plan.EnableECR {
+		enableECREnv = "ENABLE_AWS_ECR=true"
+	}
+
 	task := execute.ExecTask{
 		Command: "./scripts/deploy-cloud-components.sh",
 		Shell:   true,
-		Env:     []string{authEnv, gitlabEnv, networkPoliciesEnv},
+		Env: []string{authEnv,
+			gitlabEnv,
+			networkPoliciesEnv,
+			enableECREnv,
+		},
 	}
 
 	res, err := task.Execute()
@@ -644,6 +655,10 @@ func filterFeatures(plan types.Plan) (types.Plan, error) {
 	var err error
 
 	plan.Features = append(plan.Features, types.DefaultFeature)
+
+	if plan.EnableECR == true {
+		plan.Features = append(plan.Features, types.ECRFeature)
+	}
 
 	plan, err = filterGitRepositoryManager(plan)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -85,6 +85,22 @@ func Test_filterFeatures(t *testing.T) {
 			expectedError:    nil,
 		},
 		{
+			title: "AWS ECR is detected as a feature",
+			planConfig: types.Plan{
+				EnableECR: true,
+			},
+			expectedFeatures: []string{types.DefaultFeature, types.ECRFeature},
+			expectedError:    nil,
+		},
+		{
+			title: "AWS ECR is disabled when not set as a feature",
+			planConfig: types.Plan{
+				EnableECR: false,
+			},
+			expectedFeatures: []string{types.DefaultFeature},
+			expectedError:    nil,
+		},
+		{
 			title: "Every field which defines populated feature is populated for gitlab",
 			planConfig: types.Plan{
 				SCM: types.GitLabSCM,
@@ -123,16 +139,23 @@ func Test_filterFeatures(t *testing.T) {
 			expectedError:    nil,
 		},
 	}
+
 	for _, test := range tests {
+
 		t.Run(test.title, func(t *testing.T) {
+
 			var filterError error
 			test.planConfig, filterError = filterFeatures(test.planConfig)
 			t.Logf("Features in the plan: %v", test.planConfig.Features)
+
 			if filterError != nil && test.expectedError != nil {
+
 				if !strings.Contains(filterError.Error(), test.expectedError.Error()) {
 					t.Errorf("Expected error to contain: `%s` got: `%s`", test.expectedError.Error(), filterError.Error())
 				}
+
 			}
+
 			for _, expectedFeature := range test.expectedFeatures {
 				for allPlanFeatures, enabledFeature := range test.planConfig.Features {
 					if len(test.planConfig.Features) == 0 {

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -94,7 +94,6 @@ func Apply(plan types.Plan) error {
 	}
 
 	isGitHub := plan.SCM == "github"
-
 	stackErr := generateTemplate("stack", plan, stackConfig{
 		GitHub: isGitHub,
 	})
@@ -103,7 +102,19 @@ func Apply(plan types.Plan) error {
 		return stackErr
 	}
 
+	builderErr := generateTemplate("of-builder-dep", plan, builderConfig{
+		ECR: plan.EnableECR,
+	})
+
+	if builderErr != nil {
+		return builderErr
+	}
+
 	return nil
+}
+
+type builderConfig struct {
+	ECR bool
 }
 
 type stackConfig struct {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,8 +12,10 @@ const (
 	GitHubFeature = "scm_github"
 	// GitLabFeature filter is the feature which enables secret creation for GitLab
 	GitLabFeature = "scm_gitlab"
+
 	// Auth filter enables OAuth secret creation
 	Auth = "auth"
+
 	// GCPDNS filter enables the creation of secrets for Google Cloud Platform DNS when TLS is enabled
 	GCPDNS = "gcp_dns01"
 	// DODNS filter enables the creation of secrets for Digital Ocean DNS when TLS is enabled
@@ -27,10 +29,14 @@ const (
 	DigitalOcean = "digitalocean"
 	// Route53 is the dns_service field in yaml file for Amazon
 	Route53 = "route53"
-	// GitLabManager repository manager name as displayed in the init.yaml file
+
+	// GitLabSCM repository manager name as displayed in the init.yaml file
 	GitLabSCM = "gitlab"
-	// GitHubManager repository manager name as displayed in the init.yaml file
+	// GitHubSCM repository manager name as displayed in the init.yaml file
 	GitHubSCM = "github"
+
+	// ECRFeature enable ECR
+	ECRFeature = "ecr"
 )
 
 type Plan struct {
@@ -55,6 +61,7 @@ type Plan struct {
 	ScaleToZero          bool                     `yaml:"scale_to_zero"`
 	OpenFaaSCloudVersion string                   `yaml:"openfaas_cloud_version"`
 	NetworkPolicies      bool                     `yaml:"network_policies"`
+	EnableECR            bool                     `yaml:"enable_ecr"`
 }
 
 // Deployment is the deployment section of YAML concerning

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -5,8 +5,11 @@ cp ./tmp/generated-github.yml ./tmp/openfaas-cloud/github.yml
 cp ./tmp/generated-slack.yml ./tmp/openfaas-cloud/slack.yml
 cp ./tmp/generated-dashboard_config.yml ./tmp/openfaas-cloud/dashboard/dashboard_config.yml
 
-kubectl apply -f ./tmp/openfaas-cloud/yaml/core/of-builder-dep.yml
 kubectl apply -f ./tmp/openfaas-cloud/yaml/core/of-builder-svc.yml
+
+# Update builder for any ECR secrets needed
+cp ./tmp/generated-of-builder-dep.yml ./tmp/openfaas-cloud/yaml/core/of-builder-dep.yml
+kubectl apply -f ./tmp/openfaas-cloud/yaml/core/of-builder-dep.yml
 
 kubectl apply -f ./tmp/openfaas-cloud/yaml/core/rbac-import-secrets.yml
 
@@ -19,6 +22,7 @@ else
     #  Disable auth service by pointing the router at the echo function:
     sed s/edge-auth.openfaas/echo.openfaas-fn/g ./tmp/openfaas-cloud/yaml/core/edge-router-dep.yml | kubectl apply -f -
 fi
+
 kubectl apply -f ./tmp/openfaas-cloud/yaml/core/edge-router-svc.yml
 
 kubectl apply -f ./tmp/openfaas-cloud/yaml/core/edge-auth-svc.yml
@@ -67,6 +71,11 @@ if [ "$GITLAB" = "true" ] ; then
     cp ../generated-gitlab.yml ./gitlab.yml
     echo "Deploying gitlab functions..."
     faas deploy -f ./gitlab.yml
+fi
+
+if [ "$ENABLE_AWS_ECR" = "true" ] ; then
+    echo "Deploying AWS ECR functions (register-image)..."
+    faas deploy -f ./aws.yml
 fi
 
 cd ./dashboard

--- a/templates/gitlab.yml
+++ b/templates/gitlab.yml
@@ -63,7 +63,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.15.0
+    image: functions/of-git-tar:0.16.0
     labels:
       openfaas-cloud: "1"
       role: openfaas-system

--- a/templates/of-builder-dep.yml
+++ b/templates/of-builder-dep.yml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: of-builder
+  namespace: openfaas
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: of-builder
+    spec:
+      volumes:
+        - name: registry-secret
+          secret:
+            secretName: registry-secret
+        - name: payload-secret
+          secret:
+            secretName: payload-secret
+  {{ if .ECR }}
+        - name: ecr-credentials
+          secret:
+            defaultMode: 420
+            secretName: ecr-credentials
+  {{ end }}
+      containers:
+      - name: of-builder
+        image: openfaas/of-builder:0.7.2
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          timeoutSeconds: 2
+        env:
+          - name: enable_lchown
+            value: "true"
+          - name: insecure
+            value: "false"
+          - name: buildkit_url  
+            value: "tcp://127.0.0.1:1234"
+          - name: "disable_hmac"
+            value: "false"
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        volumeMounts:
+        - name: registry-secret
+          readOnly: true
+          mountPath: "/home/app/.docker/"
+        - name: payload-secret
+          readOnly: true
+          mountPath: "/var/openfaas/secrets/"
+  {{ if .ECR }}
+        - mountPath: /home/app/.aws/
+          readOnly: true
+          name: ecr-credentials
+  {{ end }}
+      - name: of-buildkit
+        args: ["--addr", "tcp://0.0.0.0:1234"]
+        image: moby/buildkit:v0.3.3
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 1234
+          protocol: TCP
+        securityContext:
+          privileged: true

--- a/templates/of-builder-dep.yml
+++ b/templates/of-builder-dep.yml
@@ -20,10 +20,10 @@ spec:
           secret:
             secretName: payload-secret
   {{ if .ECR }}
-        - name: ecr-credentials
+        - name: aws-ecr-credentials
           secret:
             defaultMode: 420
-            secretName: ecr-credentials
+            secretName: aws-ecr-credentials
   {{ end }}
       containers:
       - name: of-builder
@@ -58,7 +58,7 @@ spec:
   {{ if .ECR }}
         - mountPath: /home/app/.aws/
           readOnly: true
-          name: ecr-credentials
+          name: aws-ecr-credentials
   {{ end }}
       - name: of-buildkit
         args: ["--addr", "tcp://0.0.0.0:1234"]

--- a/templates/of-builder-dep.yml
+++ b/templates/of-builder-dep.yml
@@ -62,7 +62,7 @@ spec:
   {{ end }}
       - name: of-buildkit
         args: ["--addr", "tcp://0.0.0.0:1234"]
-        image: moby/buildkit:v0.3.3
+        image: moby/buildkit:v0.6.2
         imagePullPolicy: Always
         ports:
         - containerPort: 1234

--- a/templates/stack.yml
+++ b/templates/stack.yml
@@ -49,7 +49,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.15.0
+    image: functions/of-git-tar:0.16.0
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -75,7 +75,7 @@ functions:
   buildshiprun:
     lang: go
     handler: ./buildshiprun
-    image: functions/of-buildshiprun:0.11.3
+    image: functions/of-buildshiprun:0.12.0
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
Add ECR support

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

ECR support is required for some customers and users. This patch
also brings the of-builder over as a templated resource so that
the AWS secret for accessing ECR can be bound when necessary
to the register-image function and to the of-builder itself.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Automated e2e testing TBD, upstream feature tested through manual deployment.

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
