### PR TITLE
Replace use of $GOOS & $GOARCH thanks to `uname`

### DIFF
--- a/scripts/export-sealed-secret-pubcert.sh
+++ b/scripts/export-sealed-secret-pubcert.sh
@@ -2,8 +2,12 @@
 
 if [ ! -f kubeseal ];
 then
-    GOOS=$(go env GOOS)
-    GOARCH=$(go env GOARCH)
+    GOOS=$(echo $(uname -s) | tr '[:upper:]' '[:lower:]')
+    GOARCH=$(echo $(uname -m) | tr '[:upper:]' '[:lower:]')
+
+    if [ "$GOARCH" == "x86_64" ]; then
+       GOARCH="amd64"
+    fi
 
     release=$(curl -sI https://github.com/bitnami-labs/sealed-secrets/releases/latest | grep Location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
 


### PR DESCRIPTION
Signed-off-by: Nicolas Sterchele <sterchelen@gmail.com>

#134 

## Description

Replace `$GOOS` and `$GOARCH` by using `uname` command with POSIX parameters.

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
