### PR TITLE
Remove notice about canceling download of ofc-bootstrap script

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -21,8 +21,6 @@ hasCli() {
         echo
         echo "You already have the ofc-bootstrap cli!"
         export n=1
-        echo "Overwriting in $n seconds.. Press Control+C to cancel."
-        echo
         sleep $n
     fi
 


### PR DESCRIPTION
There was a notice to cancel download of the script if you had
it installed that was set to say you had 1 second to cancel.
We always install the latest version so if a user wants to
reinstall then its fine. The check has been removed.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
by running the script locally. It no longer says that the script exists and just installs it.

## Checklist:

I have:

- [X] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests

