### PR TITLE
Updrade to cert-manager 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ Flush out the staging certificates and orders
 
 ```sh
 kubectl delete certificates --all  -n openfaas
-kubectl delete secret -n openfaas -l="certmanager.k8s.io/certificate-name"
+kubectl delete secret -n openfaas -l="cert-manager.io/certificate-name"
 kubectl delete order -n openfaas --all
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,6 +72,3 @@ Status:
 
 Add all remaining steps from [installation guide](https://github.com/openfaas/openfaas-cloud/tree/master/docs).
 
-Caveats:
-
-* JetStack's cert-manager is currently pinned to an earlier version due to issues with re-creating the CRD entries. 

--- a/pkg/tls/issuer_test.go
+++ b/pkg/tls/issuer_test.go
@@ -26,7 +26,7 @@ func Test_DigitalOcean_Issuer(t *testing.T) {
 
 	templateRes.Execute(&buf, &tlsTemplate)
 
-	wantTemplate := `apiVersion: certmanager.k8s.io/v1alpha1
+	wantTemplate := `apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
@@ -83,7 +83,7 @@ func Test_Route53_Issuer(t *testing.T) {
 	buf := bytes.Buffer{}
 	templateRes.Execute(&buf, &tlsTemplate)
 
-	wantTemplate := `apiVersion: certmanager.k8s.io/v1alpha1
+	wantTemplate := `apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
@@ -141,7 +141,7 @@ func Test_GoogleCloudDNS_Issuer(t *testing.T) {
 	buf := bytes.Buffer{}
 	templateRes.Execute(&buf, &tlsTemplate)
 
-	wantTemplate := `apiVersion: certmanager.k8s.io/v1alpha1
+	wantTemplate := `apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/scripts/create-namespaces.sh
+++ b/scripts/create-namespaces.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
 
 # Install the CustomResourceDefinition resources separately
-kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.10/deploy/manifests/00-crds.yaml
+kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml
 
 kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
 
 # Create the namespace for cert-manager
 kubectl create namespace cert-manager
-
-# Label the cert-manager namespace to disable resource validation
-kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
 
 kubectl get namespaces

--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -8,5 +8,5 @@ helm repo update
 helm install \
   --name cert-manager \
   --namespace cert-manager \
-  --version v0.10.0 \
+  --version v0.11.0 \
   jetstack/cert-manager

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -9,8 +9,8 @@ kubectl delete ns openfaas openfaas-fn
 kubectl delete ns  cert-manager
 
 kubectl delete crd sealedsecrets.bitnami.com
-kubectl delete \
-    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
+kubectl delete -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml
+
 
 kubectl delete deploy/tiller-deploy -n kube-system
 kubectl delete sa/tiller -n kube-system

--- a/templates/issue-prod.yml
+++ b/templates/issue-prod.yml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/templates/k8s/tls/auth-domain-cert.yml
+++ b/templates/k8s/tls/auth-domain-cert.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: auth-system-{{.RootDomain}}

--- a/templates/k8s/tls/issuer-prod.yml
+++ b/templates/k8s/tls/issuer-prod.yml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/templates/k8s/tls/issuer-staging.yml
+++ b/templates/k8s/tls/issuer-staging.yml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging

--- a/templates/k8s/tls/wildcard-domain-cert.yml
+++ b/templates/k8s/tls/wildcard-domain-cert.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: wildcard-{{.RootDomain}}


### PR DESCRIPTION
## Description
We were pinned to cert-manager 0.10.0 before this update. There
has been a new release and we have upgraded to use 0.11.0 with its
new CRDs and new api namespace etc.

The 0.10.0 -> 0.11.0 update is a breaking change so the upgrade
instructions on the cert-manager website should be followed for
existing installs. New installs will use 0.11.0 by default

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>
Closes #138 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created a working installation init.yaml, then deleted cluster, upgraded the code components and then re-installed the application using the ofc-bootstrap script. Then verified that the installation was successful by building and running functions 

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

