### PR TITLE
Update the OpenFaaS installation to only pull images if not present

### DIFF
--- a/scripts/install-openfaas.sh
+++ b/scripts/install-openfaas.sh
@@ -18,4 +18,5 @@ helm upgrade openfaas --install openfaas/openfaas \
     --set gateway.replicas=2 \
     --set queueWorker.replicas=2 \
     --set faasIdler.dryRun=$FAAS_IDLER_DRY_RUN \
-    --set faasnetes.httpProbe=true
+    --set faasnetes.httpProbe=true \
+    --set faasnetes.imagePullPolicy=IfNotPresent


### PR DESCRIPTION
## Description
The bootstrap script installed OpenFaaS in a way that the images were
always pulled even if they existed on the node. This has been changed
to pull if they are not present to reduce cold-start times when the
functions are scaled down and up.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

Closes #100 

@alexellis is this all that is required for #100 ? seems like a small pr

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Installing OFC onto a new cluster with the new config and testing by calling the functions.
It all worked

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

