### PR TITLE
#144 Support for dry-run/generate-only mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,13 +174,34 @@ func filesExists(files []types.FileSecret) error {
 	return nil
 }
 
+func dryProcess(plan types.Plan, prefs InstallPreferences) error {
+	plan.DryRun = true
+
+	ingressErr := ingress.Apply(plan)
+	if ingressErr != nil {
+		log.Println(ingressErr)
+	}
+
+	if plan.TLS {
+		tlsErr := tls.Apply(plan)
+		if tlsErr != nil {
+			log.Println(tlsErr)
+		}
+	}
+
+	fmt.Println("Creating stack.yml")
+
+	planErr := stack.Apply(plan)
+	if planErr != nil {
+		log.Println(planErr)
+	}
+
+	return nil
+}
+
 func process(plan types.Plan, prefs InstallPreferences) error {
 	if prefs.DryRun {
-		ingressErr := ingress.Apply(plan)
-		if ingressErr != nil {
-			log.Println(ingressErr)
-		}
-		return nil
+		return dryProcess(plan, prefs)
 	}
 
 	if plan.TLS {

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -26,7 +26,7 @@ func Apply(plan types.Plan) error {
 		RootDomain: plan.RootDomain,
 		TLS:        plan.TLS,
 		IssuerType: plan.TLSConfig.IssuerType,
-	})
+	}, plan.DryRun)
 
 	if err != nil {
 		return err
@@ -36,7 +36,7 @@ func Apply(plan types.Plan) error {
 		RootDomain: plan.RootDomain,
 		TLS:        plan.TLS,
 		IssuerType: plan.TLSConfig.IssuerType,
-	})
+	}, plan.DryRun)
 
 	if err1 != nil {
 		return err1
@@ -45,7 +45,7 @@ func Apply(plan types.Plan) error {
 	return nil
 }
 
-func apply(source string, name string, ingress IngressTemplate) error {
+func apply(source string, name string, ingress IngressTemplate, dryRun bool) error {
 
 	generatedData, err := applyTemplate("templates/k8s/"+source, ingress)
 	if err != nil {
@@ -70,6 +70,10 @@ func apply(source string, name string, ingress IngressTemplate) error {
 		Command: "kubectl",
 		Args:    []string{"apply", "-f", tempFilePath},
 		Shell:   false,
+	}
+
+	if dryRun {
+		execTask.Args = append(execTask.Args, "--dry-run=true")
 	}
 
 	execRes, execErr := execTask.Execute()

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -41,7 +41,7 @@ func Apply(plan types.Plan) error {
 			return tlsTemplateErr
 		}
 
-		applyErr := applyTemplate(tempFilePath)
+		applyErr := applyTemplate(tempFilePath, plan.DryRun)
 		if applyErr != nil {
 			return applyErr
 		}
@@ -85,13 +85,16 @@ func generateTemplate(fileName string, tlsTemplate TLSTemplate) (string, error) 
 	return tempFilePath, nil
 }
 
-func applyTemplate(tempFilePath string) error {
+func applyTemplate(tempFilePath string, dryRun bool) error {
 
 	execTask := execute.ExecTask{
 		Command: "kubectl apply -f " + tempFilePath,
 		Shell:   false,
 	}
 
+	if dryRun {
+		execTask.Command = execTask.Command + " --dry-run=true"
+	}
 	execRes, execErr := execTask.Execute()
 	if execErr != nil {
 		return execErr

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -63,6 +63,7 @@ type Plan struct {
 	NetworkPolicies      bool                     `yaml:"network_policies"`
 	BuildBranch          string                   `yaml:"build_branch"`
 	EnableECR            bool                     `yaml:"enable_ecr"`
+	DryRun               bool                     `yaml:"dry"`
 }
 
 // Deployment is the deployment section of YAML concerning


### PR DESCRIPTION
## Description
#144 Support for dry-run/generate-only mode

## How Has This Been Tested?
I executed and testet on multiple machines. After executed the dry run I can apply the files easy with the scripts.

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests