### PR TITLE
add validator for registry credentials file

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,10 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/openfaas-incubator/ofc-bootstrap/pkg/validators"
 	"io/ioutil"
 	"log"
 	"os"
+	"os/user"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/alexellis/go-execute"
@@ -89,6 +93,13 @@ func main() {
 
 	os.Mkdir("tmp", 0700)
 
+	log.Println("Validating registry credentials file")
+
+	registryAuthErr := validateRegistryAuth(plan.Registry, plan.Secrets, plan.EnableECR)
+	if registryAuthErr != nil {
+		fmt.Fprint(os.Stderr, "error with registry credentials file. Please ensure it has been created correctly")
+	}
+
 	start := time.Now()
 	err := process(plan)
 	done := time.Since(start)
@@ -138,6 +149,23 @@ func validateTools(tools []string) error {
 
 }
 
+func validateRegistryAuth(regEndpoint string, planSecrets []types.KeyValueNamespaceTuple, enableECR bool) error {
+	if enableECR {
+		return nil
+	}
+	for _, planSecret := range planSecrets {
+		if planSecret.Name == "registry-secret" {
+			confFileLocation := planSecret.Files[0].ValueFrom
+			fileBytes, err := ioutil.ReadFile(expandPath(confFileLocation))
+			if err != nil {
+				return err
+			}
+			return validators.ValidateRegistryAuth(regEndpoint, fileBytes)
+		}
+	}
+	return nil
+}
+
 func validatePlan(plan types.Plan) error {
 	for _, secret := range plan.Secrets {
 		if featureEnabled(plan.Features, secret.Filters) {
@@ -148,6 +176,20 @@ func validatePlan(plan types.Plan) error {
 		}
 	}
 	return nil
+}
+func expandPath(path string) string {
+	usr, _ := user.Current()
+	dir := usr.HomeDir
+	if path == "~" {
+		// In case of "~", which won't be caught by the "else if"
+		path = dir
+	} else if strings.HasPrefix(path, "~/") {
+		// Use strings.HasPrefix so we don't match paths like
+		// "/something/~/something/"
+		path = filepath.Join(dir, path[2:])
+	}
+
+	return path
 }
 
 func filesExists(files []types.FileSecret) error {

--- a/pkg/validators/validators.go
+++ b/pkg/validators/validators.go
@@ -1,0 +1,60 @@
+package validators
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type AuthConfig struct {
+	Auth string `json:"auth,omitempty"`
+}
+
+type DockerConfigJson struct {
+	AuthConfigs map[string]AuthConfig `json:"auths"`
+}
+
+func unmarshalRegistryConfig(data []byte) (*DockerConfigJson, error) {
+	var registryConfig DockerConfigJson
+
+	err := json.Unmarshal(data, &registryConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &registryConfig, nil
+}
+
+func ValidateRegistryAuth(registryEndpoint string, configFileBytes []byte) error {
+
+	registryData, unmarshalErr := unmarshalRegistryConfig(configFileBytes)
+	if unmarshalErr != nil {
+		return unmarshalErr
+	}
+
+	noAuthErr := validate(registryData, registryEndpoint)
+	if noAuthErr != nil {
+		return noAuthErr
+	}
+
+	return nil
+}
+
+func validate(registryData *DockerConfigJson, endpoint string) error {
+	var fileEndpoint string
+	if strings.HasPrefix(endpoint, "docker.io") {
+		fileEndpoint = "https://index.docker.io/v1/"
+	} else {
+		fileEndpoint = endpoint
+	}
+	if endpointConfig, ok := registryData.AuthConfigs[fileEndpoint]; ok {
+		if endpointConfig.Auth != "" {
+			_, err := base64.StdEncoding.DecodeString(endpointConfig.Auth)
+			return err
+		} else {
+			return errors.New("docker credentials file is not valid (no base64 credentials). Please re-create this file")
+		}
+	}
+	return errors.New(fmt.Sprintf("docker auth file does not contain registry %q that you specified in config. Please use docker login", endpoint))
+}

--- a/pkg/validators/validators_test.go
+++ b/pkg/validators/validators_test.go
@@ -1,0 +1,131 @@
+package validators
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_ValidateRegistryAuthNoCredStore(t *testing.T) {
+	file := []byte(fmt.Sprintf("{ \"auths\": { \"%s\": {\"auth\": \"%s\"} } } ",
+		"https://index.docker.io/v1/",
+		"Zm9vCg=="))
+
+	got := ValidateRegistryAuth("docker.io/some-user", file)
+	if got != nil {
+		t.Errorf("error want: %s, got %s", "nil", got)
+		t.Fail()
+	}
+}
+
+func Test_ValidateRegistryAuthCredStoreNoAuth(t *testing.T) {
+	file := []byte(fmt.Sprintf("{ \"auths\": { \"%s\": {} }, \"credsStore\": \"something\" } ",
+		"https://index.docker.io/v1/"))
+	got := ValidateRegistryAuth("docker.io/some-user", file)
+	if got == nil {
+		t.Errorf("error was nil.")
+		t.Fail()
+	}
+}
+
+func Test_ValidateRegistryAuthNoCredStoreNoAuth(t *testing.T) {
+	file := []byte(fmt.Sprintf("{ \"auths\": { \"%s\": {} } } ",
+		"index.docker.io/index.html"))
+	got := ValidateRegistryAuth("docker.io/some-user", file)
+	if got == nil {
+		t.Errorf("error was nil.")
+		t.Fail()
+	}
+}
+
+func Test_ValidateRegistryAuthNoValidEndpoint(t *testing.T) {
+	file := []byte(fmt.Sprintf("{ \"auths\": { \"%s\": {} } } ",
+		""))
+	got := ValidateRegistryAuth("docker.io/some-user", file)
+	if got == nil {
+		t.Errorf("error was nil.")
+		t.Fail()
+	}
+}
+
+func Test_Validate_CorrectDetails(t *testing.T) {
+	data := createDockerConfigJson("https://index.docker.io/v1/", "Zm9vOmJhcgo=")
+
+	got := validate(data, "docker.io")
+	if got != nil {
+		t.Errorf("error want no error, got %q", got)
+		t.Fail()
+	}
+}
+
+func Test_Validate_CorrectDetailsNotDockerRegistry(t *testing.T) {
+	data := createDockerConfigJson("https://my.other.registry/auth/v22", "Zm9vOmJhcgo=")
+
+	got := validate(data, "https://my.other.registry/auth/v22")
+	if got != nil {
+		t.Errorf("error want no error, got %q", got)
+		t.Fail()
+	}
+}
+
+func Test_Validate_NoEntryForDomain(t *testing.T) {
+	data := createDockerConfigJson("http://notdocker.io/some-user", "dsonosc")
+
+	got := validate(data, "docker.io")
+	if got == nil {
+		t.Errorf("error wanted error, got %q", got)
+		t.Fail()
+	}
+}
+
+func Test_Validate_EntryDoesNotContainAuth(t *testing.T) {
+	data := createDockerConfigJson("https://index.docker.io/v1/", "Zm9vOmJhcgo=")
+
+	got := validate(data, "notdocker.io")
+	if got == nil {
+		t.Errorf("error want no error, got %q", got)
+		t.Fail()
+	}
+}
+
+func Test_Validate_EntryDoesNotContainAuthNotDocker(t *testing.T) {
+	data := createDockerConfigJson("https://index.myregistry.io/v1/", "Zm9vOmJhcgo=")
+
+	got := validate(data, "https://index.not.my.registry.io/v1/")
+	if got == nil {
+		t.Errorf("error want no error, got %q", got)
+		t.Fail()
+	}
+}
+
+func Test_Validate_EntryEmptyAuthString(t *testing.T) {
+	data := createDockerConfigJson("https://index.docker.io/v1/", "Zm9vOmJhcgo=")
+
+	got := validate(data, "docker.io")
+	if got != nil {
+		t.Errorf("error want no error, got %q", got)
+		t.Fail()
+	}
+}
+
+func Test_Validate_NonBase64AuthString(t *testing.T) {
+	data := createDockerConfigJson("https://index.docker.io/v1/", "ds:\\/onosc")
+
+	got := validate(data, "docker.io")
+	if got == nil {
+		t.Errorf("want error, got %q", got)
+		t.Fail()
+	}
+}
+
+func createDockerConfigJson(endpoint string, authString string) *DockerConfigJson {
+
+	conf := DockerConfigJson{
+		AuthConfigs: map[string]AuthConfig{
+			endpoint: {
+				Auth: authString,
+			},
+		},
+	}
+
+	return &conf
+}


### PR DESCRIPTION
## Description

The bootstrap script now checks that the registry credentials
file contains an entry for the registry that is specified in
init.yaml and it has an "auth" section which has base64
values in it.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

For users using a docker.io/user registry the credentials file that `docker login` creates uses `https://index.docker.io/v1` so there is some code in there to build this if using that registry.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. unit tests written in validators_test.go
2. Ran ofc-bootstrap script with no file, gives file not exists error
3. Ran ofc-bootstrap with file with no entry for the registry specified in init.yaml, gave error that it didnt exists for that registry
4. Ran ofc-bootstrap with file that had an entry, but it didnt have an auth section, gave an error saying it wasnt valid
5. Ran ofc-bootstrap with file that had entry and had invalid base64 credentials (empty), gave error saying it wasnt valid
6. Ran ofc-bootstrap with file that had entry but invalid base64 credentials (not base64 decodable), gave error saying wasnt valid.

closes #125 

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests

