### PR TITLE
#150 Offer support to only update secrets

### DIFF
--- a/main.go
+++ b/main.go
@@ -537,12 +537,21 @@ func createNamespaces() error {
 func createSecrets(plan types.Plan) error {
 
 	filename := "./tmp/secrets.yaml"
+
 	f, err := os.Create(filename)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
+	numberOfEnabledSecrets := 0
+	for _, secret := range plan.Secrets {
+		if featureEnabled(plan.Features, secret.Filters) {
+			numberOfEnabledSecrets++
+		}
+	}
+
+	numberOfAddedSecrets := 1
 	for _, secret := range plan.Secrets {
 		if featureEnabled(plan.Features, secret.Filters) {
 			fmt.Printf("Add secret: %s to %s\n", secret.Name, filename)
@@ -564,6 +573,15 @@ func createSecrets(plan types.Plan) error {
 				if err != nil {
 					return err
 				}
+
+				if numberOfEnabledSecrets > numberOfAddedSecrets {
+					_, err = f.WriteString("---\n")
+					if err != nil {
+						return err
+					}
+				}
+
+				numberOfAddedSecrets++
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Issue #150. Added support so you can update your secrets with anything else. Change the use from `kubectl create` to `kubectl apply`

## How Has This Been Tested?
Have testet multiple times on different setup

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests