### PR TITLE
Update Registry Auth file validation to remove duplicated code

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,10 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/user"
-	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/alexellis/go-execute"
@@ -164,8 +161,8 @@ func validateRegistryAuth(regEndpoint string, planSecrets []types.KeyValueNamesp
 	}
 	for _, planSecret := range planSecrets {
 		if planSecret.Name == "registry-secret" {
-			confFileLocation := planSecret.Files[0].ValueFrom
-			fileBytes, err := ioutil.ReadFile(expandPath(confFileLocation))
+			confFileLocation := planSecret.Files[0].ExpandValueFrom()
+			fileBytes, err := ioutil.ReadFile(confFileLocation)
 			if err != nil {
 				return err
 			}
@@ -185,20 +182,6 @@ func validatePlan(plan types.Plan) error {
 		}
 	}
 	return nil
-}
-func expandPath(path string) string {
-	usr, _ := user.Current()
-	dir := usr.HomeDir
-	if path == "~" {
-		// In case of "~", which won't be caught by the "else if"
-		path = dir
-	} else if strings.HasPrefix(path, "~/") {
-		// Use strings.HasPrefix so we don't match paths like
-		// "/something/~/something/"
-		path = filepath.Join(dir, path[2:])
-	}
-
-	return path
 }
 
 func filesExists(files []types.FileSecret) error {


### PR DESCRIPTION
## Description

When this was implemented the fs.ExpandValueFrom function was not
used, instead it's own version of implementing ~/ --> /user/home/
was created. This commit removes that duplicated codes and instead
uses the tried and tested code in ExpandValueFrom

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
building and running ofc-bootstrap finds the correct ~/ --> /User/{{my-user}} on mac.


## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

