### PR TITLE
Rename --registry-url to --server in registry-login

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ If you are using Dockerhub you only need to supply your `--username` and `--pass
 ofc-bootstrap registry-login --username <your-registry-username> --password <your-registry-password>
 ```
 
-If you are using a different registry (that is not ECR) then also provide a `--registry-url` as well
+If you are using a different registry (that is not ECR) then also provide a `--server` as well.
 
 
 Find the section of the YAML `registry: docker.io/ofctest/`

--- a/cmd/registry_login.go
+++ b/cmd/registry_login.go
@@ -13,7 +13,7 @@ import (
 
 func init() {
 	rootCommand.AddCommand(registryLoginCommand)
-	registryLoginCommand.Flags().String("registry-url", "https://index.docker.io/v1/", "The Registry URL, it is defaulted to the docker registry")
+	registryLoginCommand.Flags().String("server", "https://index.docker.io/v1/", "The server URL, it is defaulted to the docker registry")
 	registryLoginCommand.Flags().String("username", "", "The Registry Username")
 	registryLoginCommand.Flags().String("password", "", "The registry password")
 
@@ -35,18 +35,18 @@ func generateRegistryAuthFile(command *cobra.Command, _ []string) error {
 	region, _ := command.Flags().GetString("region")
 	username, _ := command.Flags().GetString("username")
 	password, _ := command.Flags().GetString("password")
-	registryURL, _ := command.Flags().GetString("registry-url")
+	server, _ := command.Flags().GetString("server")
 
 	if ecrEnabled {
 		return generateECRFile(accountID, region)
 	} else {
-		return generateFile(username, password, registryURL)
+		return generateFile(username, password, server)
 	}
 }
 
-func generateFile(username string, password string, registryURL string) error {
+func generateFile(username string, password string, server string) error {
 
-	fileBytes, err := generateRegistryAuth(registryURL, username, password)
+	fileBytes, err := generateRegistryAuth(server, username, password)
 	if err != nil {
 		return err
 	}
@@ -75,15 +75,15 @@ func generateECRFile(accountID string, region string) error {
 	return writeErr
 }
 
-func generateRegistryAuth(registryURL, username, password string) ([]byte, error) {
-	if len(username) == 0 || len(password) == 0 || len(registryURL) == 0 {
-		return nil, errors.New("both --username and --password-stdin must be used, and provided, for us to generate a valid file")
+func generateRegistryAuth(server, username, password string) ([]byte, error) {
+	if len(username) == 0 || len(password) == 0 || len(server) == 0 {
+		return nil, errors.New("both --username and --password must be used, and provided, for us to generate a valid file")
 	}
 
 	encodedString := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 	data := RegistryAuth{
 		AuthConfigs: map[string]Auth{
-			registryURL: {Base64AuthString: encodedString},
+			server: {Base64AuthString: encodedString},
 		},
 	}
 


### PR DESCRIPTION
## Description

Rename the flag to be the same as used in docker (see this comment: https://github.com/openfaas/openfaas.github.io/pull/148#discussion_r358309710)

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
built the new binary and ran it. It worked. 

I have updated the readme too.

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

