### PR TITLE
Add section for ECR Config, can now set AWS region for register-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ OpenFaaS Cloud also supports Amazon's managed container registry called ECR.
 
 * Set `enable_ecr: true` in `init.yaml`
 
-* Define a `config.json` by running the following command
+* Set your AWS region `ecr_region: "your-aws-region"` in `init.yaml`
+ 
+* Define a `./credentials/config.json` by running the following command
 
 ```sh
 ofc-bootstrap registry-login --ecr --region <your-aws-region> --account-id <your-account-id>

--- a/example.init.yaml
+++ b/example.init.yaml
@@ -187,6 +187,11 @@ registry: docker.io/ofctest/
 ### Enable only if using AWS ECR
 enable_ecr: false
 
+### Change if your using ECR
+ecr_config:
+  ### The region to use for ECR
+  ecr_region: "eu-central-1"
+
 ### Your root DNS domain name, this can be a sub-domain i.e. staging.o6s.io / prod.o6s.io
 root_domain: "myfaas.club"
 

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -112,6 +112,14 @@ func Apply(plan types.Plan) error {
 		return builderErr
 	}
 
+	ecrErr := generateTemplate("aws", plan, awsConfig{
+		ECRRegion: plan.ECRConfig.ECRRegion,
+	})
+
+	if ecrErr != nil {
+		return ecrErr
+	}
+
 	return nil
 }
 
@@ -121,6 +129,10 @@ type builderConfig struct {
 
 type stackConfig struct {
 	GitHub bool
+}
+
+type awsConfig struct {
+	ECRRegion string
 }
 
 func generateTemplate(fileName string, plan types.Plan, templateType interface{}) error {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -67,6 +67,7 @@ type Plan struct {
 	NetworkPolicies      bool                     `yaml:"network_policies"`
 	BuildBranch          string                   `yaml:"build_branch"`
 	EnableECR            bool                     `yaml:"enable_ecr"`
+	ECRConfig            ECRConfig                `yaml:"ecr_config"`
 }
 
 // Deployment is the deployment section of YAML concerning
@@ -148,4 +149,8 @@ type TLSConfig struct {
 	IssuerType  string `yaml:"issuer_type"`
 	Region      string `yaml:"region"`
 	AccessKeyID string `yaml:"access_key_id"`
+}
+
+type ECRConfig struct {
+	ECRRegion string `yaml:"ecr_region"`
 }

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -4,6 +4,7 @@ cp ./tmp/generated-gateway_config.yml ./tmp/openfaas-cloud/gateway_config.yml
 cp ./tmp/generated-github.yml ./tmp/openfaas-cloud/github.yml
 cp ./tmp/generated-slack.yml ./tmp/openfaas-cloud/slack.yml
 cp ./tmp/generated-dashboard_config.yml ./tmp/openfaas-cloud/dashboard/dashboard_config.yml
+cp ./tmp/generated-aws.yml ./tmp/openfaas-cloud/aws.yml
 
 kubectl apply -f ./tmp/openfaas-cloud/yaml/core/of-builder-svc.yml
 

--- a/templates/aws.yml
+++ b/templates/aws.yml
@@ -1,0 +1,24 @@
+provider:
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  # register-image creates a repo in a hosted/managed registry, which is needed 
+  # for AWS ECR before any image can be pushed.
+  register-image:
+    lang: go
+    handler: ./register-image
+    image: functions/register-image:0.1.1
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+      com.openfaas.scale.zero: false
+    environment:
+      write_debug: true
+      read_debug: true
+      content_type: "application/json"
+      AWS_DEFAULT_REGION: "{{.ECRRegion}}"
+      AWS_SHARED_CREDENTIALS_FILE: "/var/openfaas/secrets/credentials"
+    secrets:
+      - payload-secret
+      - aws-ecr-createrepo-credentials


### PR DESCRIPTION
## Description
Previously we could enable ECR but there was a env variable set in aws.yml
that we couldn't override in ofc-bootstrap (it defaulted to eu-central-1)
We can now set this in init.yaml to be whatever region we want and it
gets passed through to the function

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>


closes #155 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added the setting to my init.yaml, then deployed using ofc-bootstrap to a new k3d cluster. Checked the deployment and it was the value I set in init.yaml


<img width="673" alt="Screenshot 2019-12-20 at 08 46 56" src="https://user-images.githubusercontent.com/40488132/71242628-47d2e180-2306-11ea-93b7-df4b4a4d0067.png">


## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

