### PR TITLE
Add a password STDIN option to registry login

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,14 @@ After the installation has completed in a later step, you will need to create DN
 
 ofc-bootstrap has a command to generate the registry auth file in the correct format.
 
-If you are using Dockerhub you only need to supply your `--username` and `--password`.
+If you are using Dockerhub you only need to supply your `--username` and `--password-stdin` (or `--password`, but this leaves the password in history).
 ```sh
-ofc-bootstrap registry-login --username <your-registry-username> --password <your-registry-password>
+
+ofc-bootstrap registry-login --username <your-registry-username> --password-stdin
+(the enter your password and hit return)
 ```
+
+You could also have you password in a file, or environment variable and echo/cat this instead of entering interactively
 
 If you are using a different registry (that is not ECR) then also provide a `--server` as well.
 


### PR DESCRIPTION
## Description

I had not added the --password-stdin option to
registry-login command, it has now been added so
users dont leave stuff in history

closes #169 
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>




## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`go build && echo $PASSWORD | ./ofc-bootstrap registry-login --username foo --password-stdin`
creates the same file as 
`go build && ./ofc-bootstrap registry-login --username foo --password $PASSWORD`

(tested by creating both and using `diff`to check they are identical

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

