### PR TITLE
Update README to clarify Route53 Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,9 @@ You can start out by using the Staging issuer, then switch to the production iss
 
 * Set `issuer_type: "prod"` (recommended) or `issuer_type: "staging"` (for testing)
 
+
+> Hint: For aws route53 DNS, create your secret key file `~/Downloads/route53-secret-access-key` (the default location) with only the secret access key, no newline and no other characters.
+
 > Note if you want to switch from the staging TLS certificates to production certificates, see the appendix.
 
 #### Enable dockerfile language support (optional)


### PR DESCRIPTION
## Description
Update the README to clarify for route53 users the format of the dns secret access key file.

After chatting to Alex on slack its well documented in the blog post : https://www.openfaas.com/blog/eks-openfaas-cloud-build-guide/

but missing some info in the ofc-bootstrap readme. This has been added. I believe its not just me that has had issues with this (and iv had issues with it a few times and can never remember the correct way to do it!)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually. Docs change

## Checklist:

I have:

- [ x checked my changes follow the style of the existing code / OpenFaaS repos
- [ x updated the documentation and/or roadmap in README.md
- [ x read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

