### PR TITLE
Add ip to create-github-command so browser opens on Linux

### DIFF
--- a/cmd/create_github.go
+++ b/cmd/create_github.go
@@ -107,7 +107,7 @@ func receiveGitHubApp(ctx context.Context, inputMap map[string]string, resCh cha
 
 	defer server.Shutdown(ctx)
 
-	localURL, err := url.Parse("http://" + server.Addr)
+	localURL, err := url.Parse("http://" + "127.0.0.1" + server.Addr)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description
The linux use for the new create-github-app command didn't open the
browser and point it to the correct place, it just left the url blank.
This change means the browser opens correctly on Linux.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By building and running, as shown below:
```
heyal@heyal-xps:~/go/src/github.com/openfaas-incubator/ofc-bootstrap$ go build && ./ofc-bootstrap create-github-app --root-domain ofc.heyal.co.uk --insecure
Name: OFC suspicious montalcini6        Root domain: ofc.heyal.co.uk    Scheme: http
Launching browser: http://127.0.0.1:30010
Starting local HTTP server on port 30010
Please complete the workflow in the browser to create your GitHub App.

```
![Screenshot from 2020-01-12 13-36-39](https://user-images.githubusercontent.com/40488132/72219680-a162b080-3540-11ea-8d5c-2cc6c222fd62.png)

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

