### PR TITLE
Change the order of checking cert-manager is ready before moving on

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -278,11 +278,6 @@ func process(plan types.Plan, prefs InstallPreferences) error {
 		log.Println(functionAuthErr.Error())
 	}
 
-	ofErr := installOpenfaas(plan.ScaleToZero)
-	if ofErr != nil {
-		log.Println(ofErr)
-	}
-
 	if plan.TLS {
 		for i := 0; i < retries; i++ {
 			log.Printf("Is cert-manager ready? %d/%d\n", i+1, retries)
@@ -292,6 +287,11 @@ func process(plan types.Plan, prefs InstallPreferences) error {
 			}
 			time.Sleep(time.Second * 2)
 		}
+	}
+
+	ofErr := installOpenfaas(plan.ScaleToZero)
+	if ofErr != nil {
+		log.Println(ofErr)
 	}
 
 	ingressErr := ingress.Apply(plan)


### PR DESCRIPTION
## Description

We currently install cert-manager, then just install openfaas chart
then we check if cert-manager is ready. This leads to openfaas failing
to install because the webhooks for cert-manager don't exist and helm
fails if any of the endpoints are not ready. See issue:
helm/helm#6361

This has been tested by running before changing the code, and openfaas
failed to install. Then I changed the order and ran against a new cluster.
This install worked as expected.

Fixes #178 
Fixes #168
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by running before changing the code, and openfaas
failed to install. Then I chnged the order and ran against a new cluster.

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

