### PR TITLE
Use license-check docker image instead of curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
+FROM teamserverless/license-check:0.3.6 as license-check
+
 # Build stage
 FROM golang:1.13 as builder
 ENV GO111MODULE=off
 
 ENV CGO_ENABLED=0
 
-WORKDIR /usr/bin/
-RUN curl -sLSf https://raw.githubusercontent.com/alexellis/license-check/master/get.sh | sh
+COPY --from=license-check /license-check /usr/bin/
 
 WORKDIR /go/src/github.com/openfaas-incubator/ofc-bootstrap
 COPY . .

--- a/Dockerfile.redist
+++ b/Dockerfile.redist
@@ -1,11 +1,12 @@
+FROM teamserverless/license-check:0.3.6 as license-check
+
 # Build stage
 FROM golang:1.13 as builder
 ENV GO111MODULE=off
 
 ENV CGO_ENABLED=0
 
-WORKDIR /usr/bin/
-RUN curl -sLSf https://raw.githubusercontent.com/alexellis/license-check/master/get.sh | sh
+COPY --from=license-check /license-check /usr/bin/
 
 WORKDIR /go/src/github.com/openfaas-incubator/ofc-bootstrap
 COPY . .


### PR DESCRIPTION
## Description

Optimizes Docker builds by copying from license-check Docker image instead of using curl to download the tool.

Ref: https://github.com/openfaas/faas/issues/1440

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`make build` and all containers passed license-check

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

