### PR TITLE
Bump cert-manager to 0.13.0

### DIFF
--- a/scripts/create-namespaces.sh
+++ b/scripts/create-namespaces.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install the CustomResourceDefinition resources separately
-kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml
+kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.13/deploy/manifests/00-crds.yaml
 
 kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
 

--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -8,6 +8,6 @@ helm repo update
 helm upgrade --install \
   cert-manager \
   --namespace cert-manager \
-  --version v0.11.0 \
+  --version v0.13.0 \
   jetstack/cert-manager \
   --wait 


### PR DESCRIPTION
## Description
There's a bug in cert-manager with domain names which have a dot at char 52

https://github.com/jetstack/cert-manager/pull/2516

I hit this with a domain and its annoying. This release (0.13.0) fixed that



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Installed OFC on a cluster and got certs for my domain.

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests