### PR TITLE
Make Grep case insensitive in download script

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -16,7 +16,7 @@ export BINLOCATION="/usr/local/bin"
 # Content common across repos #
 ###############################
 
-version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep Location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
+version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep -i location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
 if [ ! $version ]; then
     echo "Failed while attempting to install $REPO. Please manually install:"
     echo ""


### PR DESCRIPTION
##Description

Github made the location header lowercase, so our get.sh script was
failing. This makes the grep case inseneitive.




## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by running the script to make sure it failed, then making the
grep into a `grep -i` and running again, this time it worked.

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests