### PR TITLE
Added check for template file

### DIFF
--- a/cmd/create_github.go
+++ b/cmd/create_github.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"runtime"
 	"strings"
 	"time"
@@ -62,6 +63,10 @@ func createGitHubAppE(command *cobra.Command, _ []string) error {
 	inputMap := map[string]string{
 		"AppName":     name,
 		"GitHubEvent": fmt.Sprintf("%s://system.%s/github-event", scheme, rootDomain),
+	}
+
+	if _, err := os.Stat(path.Join("./pkg/github", "index.html")); err != nil {
+		return fmt.Errorf(`cannot find template "index.html", run this command from the ofc-bootstrap repository`)
 	}
 
 	fmt.Printf("Name: %s\tRoot domain: %s\tScheme: %v\n", name, rootDomain, scheme)


### PR DESCRIPTION
## Description
Added check to verify template file exists, if not, an informative message is printed.

Fixes #194 

## How Has This Been Tested?
Run the test from project's root directory:
```
./bin/ofc-bootstrap create-github-app --root-domain test
Name: OFC elegant leavitt5	Root domain: test	Scheme: https
Launching browser: http://127.0.0.1:30010
Starting local HTTP server on port 30010
Please complete the workflow in the browser to create your GitHub App.
^C
```
Run the test from outside:
```
kaderno@kaderno-XPS-13-9360:~/go/src/github.com$ ./ofc-bootstrap/bin/ofc-bootstrap create-github-app --root-domain test
Error: Cannot find the template file. You need to run this command from the root directory of the repository.
```
## Checklist:

I have:

- [X] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests

