### PR TITLE
Upgrade ofc-bootstrap to 0.13.7 OFC

### DIFF
--- a/example.init.yaml
+++ b/example.init.yaml
@@ -327,4 +327,4 @@ network_policies: false
 build_branch: master
 
 ## Version of OpenFaaS Cloud from https://github.com/openfaas/openfaas-cloud/releases/
-openfaas_cloud_version: 0.13.6
+openfaas_cloud_version: 0.13.7

--- a/templates/stack.yml
+++ b/templates/stack.yml
@@ -144,7 +144,7 @@ functions:
   import-secrets:
     lang: go
     handler: ./import-secrets
-    image: functions/import-secrets:0.6.1
+    image: functions/import-secrets:0.6.2
     annotations:
       com.openfaas.serviceaccount: sealedsecrets-importer-rw
     labels:


### PR DESCRIPTION
## Description
0.13.7 was released yesterday, this bumps the versions to be in-line with that release

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran on a cluster to upgrade

## Checklist:

I have:

- [ ] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests