### PR TITLE
Add cookie_root_domain to system dashboard

### DIFF
--- a/templates/dashboard_config.yml
+++ b/templates/dashboard_config.yml
@@ -10,3 +10,5 @@ environment:
   pretty_url: {{.Scheme}}://user.{{.RootDomain}}/function
   # Comment out if not using public pretty-URL
   query_pretty_url: 'true'
+  # Cookie root domain is needed to remove OAuth tokens when using OAuth, it doesnt matter if its set when not using OAuth
+  cookie_root_domain: '.system.{{.RootDomain}}'


### PR DESCRIPTION
## Description
The env var for cookie_root_domain was missing from the system_dashboard
deployment, this meant when users with OAuth enabled did not get their
token removed when clicking logout.


see openfaas/openfaas-cloud#623
see openfaas/openfaas-cloud#624


Signed-off-by: Alistair Hey <alistair@heyal.co.uk>




## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested by updating an existing deployment with the new setting
and logging out, the cookie was removed and the oauth flow was triggered
to gain a new token

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

