### PR TITLE
upgrade to OFC 0.13.9 and implement Secure Cookie

### DIFF
--- a/example.init.yaml
+++ b/example.init.yaml
@@ -326,4 +326,4 @@ network_policies: false
 build_branch: master
 
 ## Version of OpenFaaS Cloud from https://github.com/openfaas/openfaas-cloud/releases/
-openfaas_cloud_version: 0.13.7
+openfaas_cloud_version: 0.13.9

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -34,7 +34,7 @@ type authConfig struct {
 	OAuthProvider         string
 	OAuthProviderBaseURL  string
 	OFCustomersSecretPath string
-	TLSEnabled			  bool
+	TLSEnabled            bool
 }
 
 type builderConfig struct {
@@ -119,7 +119,7 @@ func Apply(plan types.Plan) error {
 			OAuthProvider:         plan.SCM,
 			OAuthProviderBaseURL:  plan.OAuth.OAuthProviderBaseURL,
 			OFCustomersSecretPath: ofCustomersSecretPath,
-			TLSEnabled: plan.TLS,
+			TLSEnabled:            plan.TLS,
 		}); ofAuthDepErr != nil {
 			return ofAuthDepErr
 		}

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -34,6 +34,7 @@ type authConfig struct {
 	OAuthProvider         string
 	OAuthProviderBaseURL  string
 	OFCustomersSecretPath string
+	TLSEnabled			  bool
 }
 
 type builderConfig struct {
@@ -118,6 +119,7 @@ func Apply(plan types.Plan) error {
 			OAuthProvider:         plan.SCM,
 			OAuthProviderBaseURL:  plan.OAuth.OAuthProviderBaseURL,
 			OFCustomersSecretPath: ofCustomersSecretPath,
+			TLSEnabled: plan.TLS,
 		}); ofAuthDepErr != nil {
 			return ofAuthDepErr
 		}

--- a/templates/edge-auth-dep.yml
+++ b/templates/edge-auth-dep.yml
@@ -80,6 +80,11 @@ spec:
           - name: write_debug
             value: "false"
 
+          # Config for setting the cookie to "secure", set this to true for HTTPS only OAuth
+          - name: secure_cookie
+            value: "{{.tls}}"
+
+
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/templates/edge-auth-dep.yml
+++ b/templates/edge-auth-dep.yml
@@ -72,17 +72,14 @@ spec:
             value: "{{.Scheme}}://auth.system.{{.RootDomain}}"
           - name: cookie_root_domain
             value: ".system.{{.RootDomain}}"
-
 # This is a default and can be overridden
           - name: customers_url
             value: "{{.CustomersURL}}"
-
           - name: write_debug
             value: "false"
-
           # Config for setting the cookie to "secure", set this to true for HTTPS only OAuth
           - name: secure_cookie
-            value: "{{.tls}}"
+            value: "{{.TLSEnabled}}"
 
 
         ports:


### PR DESCRIPTION
## Description
Implement SecureCookie setting for edge-auth, if using TLS  a user's cookie is now set to "secure" allowing it only to be sent over HTTPS improving security.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deploying an OFC installation with TLS and checking cookie's secure setting is "true"

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

