### PR TITLE
Refactor and Add ingress-operator as install opetion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,6 @@ static:
 dist:
 	./build_redist.sh
 
+fmt:
+	go fmt ./...
+

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -323,7 +323,7 @@ func process(plan types.Plan, prefs InstallPreferences, additionalPaths []string
 		log.Println(functionAuthErr.Error())
 	}
 
-	ofErr := installOpenfaas(plan.ScaleToZero, additionalPaths)
+	ofErr := installOpenfaas(plan.ScaleToZero, plan.IngressOperator, additionalPaths)
 	if ofErr != nil {
 		log.Println(ofErr)
 	}
@@ -501,7 +501,7 @@ func installSealedSecrets() error {
 	return nil
 }
 
-func installOpenfaas(scaleToZero bool, additionalPaths []string) error {
+func installOpenfaas(scaleToZero, ingressOperator bool, additionalPaths []string) error {
 	log.Println("Creating OpenFaaS")
 
 	task := execute.ExecTask{
@@ -509,6 +509,7 @@ func installOpenfaas(scaleToZero bool, additionalPaths []string) error {
 		Shell:   true,
 		Env: []string{
 			fmt.Sprintf("FAAS_IDLER_DRY_RUN=%v", strconv.FormatBool(!scaleToZero)),
+			fmt.Sprintf("INSTALL_INGRESS_OPERATOR=%v", strconv.FormatBool(ingressOperator)),
 		},
 		StreamStdio: true,
 	}

--- a/example.init.yaml
+++ b/example.init.yaml
@@ -326,4 +326,7 @@ network_policies: false
 build_branch: master
 
 ## Version of OpenFaaS Cloud from https://github.com/openfaas/openfaas-cloud/releases/
-openfaas_cloud_version: 0.13.9
+openfaas_cloud_version: 0.13.10
+
+## This setting, if true, will install the openfaas ingress-operator
+enable_ingress_operator: false

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -69,6 +69,7 @@ type Plan struct {
 	EnableECR            bool                     `yaml:"enable_ecr,omitempty"`
 	ECRConfig            ECRConfig                `yaml:"ecr_config,omitempty"`
 	CustomersSecret      bool                     `yaml:"customers_secret,omitempty"`
+	IngressOperator      bool                     `yaml:"enable_ingress_operator,omitempty"`
 }
 
 // Deployment is the deployment section of YAML concerning

--- a/scripts/install-openfaas.sh
+++ b/scripts/install-openfaas.sh
@@ -21,6 +21,7 @@ helm upgrade openfaas --install openfaas/openfaas \
     --set queueWorker.replicas=2 \
     --set faasIdler.dryRun=$FAAS_IDLER_DRY_RUN \
     --set faasnetes.httpProbe=true \
-    --set faasnetes.imagePullPolicy=IfNotPresent
+    --set faasnetes.imagePullPolicy=IfNotPresent \
+    --set ingressOperator.create=$INSTALL_INGRESS_OPERATOR
 
 kubectl rollout status -n openfaas deploy/gateway --timeout=5m


### PR DESCRIPTION
## Description

Iv added and tested that we can install ingress-operator using the
openfaas helm  chart.


Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by building and running locally and then adding a FNI resource
and validating the route and certs were created

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

