### PR TITLE
Update registry_login.go

### DIFF
--- a/cmd/registry_login.go
+++ b/cmd/registry_login.go
@@ -23,7 +23,7 @@ var registryLoginCommand = &cobra.Command{
 func init() {
 	rootCommand.AddCommand(registryLoginCommand)
 
-	registryLoginCommand.Flags().String("server", "https://index.docker.io/v1/", "The server URL, it is defaulted to the docker registry")
+	registryLoginCommand.Flags().String("server", "https://index.docker.io/v2/", "The server URL, it is defaulted to the docker registry")
 	registryLoginCommand.Flags().String("username", "", "The Registry Username")
 	registryLoginCommand.Flags().String("password", "", "The registry password")
 	registryLoginCommand.Flags().BoolP("password-stdin", "s", false, "Reads the gateway password from stdin")


### PR DESCRIPTION
/v1/ is throwing 404s

## Description
docker /v1/ path is throwing URLs - looks to be no longer supported. Therefore was not able to generate the ./credentials/config.json file for access.

## How Has This Been Tested?
unable to test on my current machine


## Checklist:

I have:

- [ ] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests

