### PR TITLE
Update docs to clarify registry-login command

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -183,7 +183,7 @@ If you are using Dockerhub you only need to supply your `--username` and `--pass
 ```sh
 
 ofc-bootstrap registry-login --username <your-registry-username> --password-stdin
-(the enter your password and hit return)
+(then enter your password and use ctrl+d to finish input)
 ```
 
 You could also have you password in a file, or environment variable and echo/cat this instead of entering interactively

--- a/cmd/registry_login.go
+++ b/cmd/registry_login.go
@@ -26,7 +26,7 @@ func init() {
 	registryLoginCommand.Flags().String("server", "https://index.docker.io/v1/", "The server URL, it is defaulted to the docker registry")
 	registryLoginCommand.Flags().String("username", "", "The Registry Username")
 	registryLoginCommand.Flags().String("password", "", "The registry password")
-	registryLoginCommand.Flags().BoolP("password-stdin", "s", false, "Reads the gateway password from stdin")
+	registryLoginCommand.Flags().BoolP("password-stdin", "s", false, "Reads the docker password from stdin, either pipe to the command or remember to press ctrl+d when reading interactively")
 
 	registryLoginCommand.Flags().Bool("ecr", false, "If we are using ECR we need a different set of flags, so if this is set, we need to set --username and --password")
 	registryLoginCommand.Flags().String("account-id", "", "Your AWS Account id")


### PR DESCRIPTION
## Description


The registry-login usage command was copied from faas-cli and doent look
like it was changed, the password-stdin flag was referencing the gateway
password.

This also changes the docs to specify pressing ctrl+d when trying a
password to close the input.

Spotted these when looking into #220 

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
building and running the command on linux

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

