### PR TITLE
Update of-builder image

### DIFF
--- a/templates/of-builder-dep.yml
+++ b/templates/of-builder-dep.yml
@@ -32,7 +32,7 @@ spec:
   {{ end }}
       containers:
       - name: of-builder
-        image: openfaas/of-builder:0.7.2
+        image: openfaas/of-builder:0.8.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Signed-off-by: Brandon Wilson <brandon@coil.com>

## Description
Updates `of-builder` image to `0.8.0`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Re-ran `ofc-bootstrap apply --file init.yaml` on a cluster that had previously been deployed using the [user guide](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/USER_GUIDE.md).
Successfully deployed a function using the [`GO111MODULE`](https://github.com/openfaas/openfaas-cloud/pull/653) build arg.

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

